### PR TITLE
DeveloperSetupGuide.md protobuf version required.

### DIFF
--- a/doc/DeveloperSetupGuide.md
+++ b/doc/DeveloperSetupGuide.md
@@ -33,7 +33,7 @@ The following packages are required to build Omaha:
     * Get the SCT source [here](http://code.google.com/p/swtoolkit/), either via direct download or via SVN checkout.
   * The GO programming language
     * Download [here](https://golang.org/dl/) 
-  * Google Protocol Buffers [here](https://github.com/google/protobuf/releases).
+  * Google Protocol Buffers (3.6.0 or higher) [here](https://github.com/google/protobuf/releases).
     * From the [release page](https://github.com/google/protobuf/releases), download the zip file protoc-$VERSION-win32.zip. It contains the protoc binary. Unzip the contents under C:\protobuf. After that, download the zip file protobuf-cpp-$VERSION.zip. Unzip the "src" sub-directory contents to C:\protobuf\src. If other directory is used, please edit the environment variables in the hammer.bat, specifically, OMAHA_PROTOBUF_BIN_DIR and OMAHA_PROTOBUF_SRC_DIR.
   * Third-party dependecies:
     * breakpad. Source code [here](https://code.google.com/p/google-breakpad/source/checkout)


### PR DESCRIPTION
A dependency on 'protobuf/implicit_weak_message.cc' was added on PR 441e20999427f0af9f1aabb35ac98682bdd7c49f. This file only exists on protobuf version 3.6.0 and higher and user older versions (which used to work before) now causes a build break.
This pull request updates the guide to specify the new requirement.