### PR TITLE
Update WINVER to Windows 7 value.

### DIFF
--- a/doc/DeveloperSetupGuide.md
+++ b/doc/DeveloperSetupGuide.md
@@ -10,9 +10,9 @@ We are striving to make the code build with the latest Windows toolchain from Mi
 
 The following packages are required to build Omaha:
   * A copy of the Omaha source code.  This can be done by cloning this repository.
-  * Microsoft Visual Studio 2015 Update 3. The free Visual Studio Community edition is sufficient to build.
-    * The Express Editions are not sufficient - they do not include ATL/MFC headers or libraries, which Omaha requires.
-  * ATL Server headers 
+  * Microsoft Visual Studio 2017. The free Visual Studio Community edition is sufficient to build.
+    * Download [here](https://visualstudio.microsoft.com/downloads)
+  * ATL Server headers
     * Download [here](http://atlserver.codeplex.com). Omaha needs this library for regular expression support.
   * Windows 10 SDK.
     * Download Windows 10 SDK [here](https://dev.windows.com/en-us/downloads/windows-10-sdk).
@@ -58,7 +58,7 @@ To run the unit tests, one more package is needed. Download the Windows Sysinter
       d---rwx---+ 1 sorin Domain Users   0 Jun 30 17:58 common
       d---rwx---+ 1 sorin Domain Users   0 Jul 15 11:34 omaha
       d---rwx---+ 1 sorin Domain Users   0 Jun 30 17:58 third_party
-      
+
       d:\src\omahaopensource\omaha>ls -l third_party
       total 16
       d---rwx---+ 1 sorin          Domain Users 0 Jul 14 12:52 breakpad

--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -162,8 +162,7 @@ win_env['ENV']['GOROOT'] = os.getenv('GOROOT',
                                      '\\..\\third_party\\go\\files')
 
 # Append paths for supporting tools such as uuidgen.exe and mage.exe.
-win_env.AppendENVPath('PATH', (_sdk_dir + '\\bin\\' +
-    ('', 'x86')[_msc_ver >= omaha_version_utils.VC120]))
+win_env.AppendENVPath('PATH', (os.environ['WindowsSdkVerBinPath'] + '\\x86\\'))
 win_env.AppendENVPath('PATH', os.getenv('OMAHA_NETFX_TOOLS_DIR'))
 
 # Remove this value because it conflicts with a #define
@@ -527,9 +526,9 @@ win_env.AppendUnique(
     # Defines for windows environment.
     CPPDEFINES = [
         'PSAPI_VERSION=1',
-        # Use _WIN32_WINNT_WS03 (0x0502)
-        'WINVER=0x0502',
-        '_WIN32_WINNT=0x0502',
+        # Use _WIN32_WINNT_WIN7 (0x0601)
+        'WINVER=0x0601',
+        '_WIN32_WINNT=0x0601',
         'WIN32', '_WINDOWS',
         'UNICODE', '_UNICODE',
         'WIN32_LEAN_AND_MEAN',
@@ -560,8 +559,8 @@ win_env.AppendUnique(
         # Windows XP. Therefore, the code needs to gracefully handle the
         # cases where some of the functionality enabled by the platform SDK
         # headers is not available.
-        # Use NTDDI_WINXPSP3 (0x05010300)
-        'NTDDI_VERSION=0x05010300',
+        # Use NTDDI_WIN7 (0x06010000)
+        'NTDDI_VERSION=0x06010000',
 
         # don't define min and max in windef.h
         'NOMINMAX',

--- a/omaha/precompile/precompile.h
+++ b/omaha/precompile/precompile.h
@@ -30,7 +30,16 @@
 #undef RegisterEventSource
 #define RegisterEventSource(x, ...) NULL
 
+#if (_MSC_VER == 1916)
+#pragma warning(push)
+#pragma warning(disable:5031) // Suppress warning C5031: #pragma warning(pop): likely mismatch, popping warning state pushed in different file
+#endif
 #include <winioctl.h>
+#if (_MSC_VER == 1916)
+#pragma warning(pop) // Works around problem in winioctl.h introduced with VS 2017 15.9
+#pragma warning(pop) // #pragma warning(disable:5031)
+#endif
+
 #include <wtypes.h>
 #include <tchar.h>
 #include <strsafe.h>


### PR DESCRIPTION
Add workaround for latest VS 2017 15.9 updates which break when `winioctl.h` is included due to an unmatched `#pragma warning(push)`.
Fix mismatched values of WINVER and NTDDI_VERSION (see #145 ).
Update the value to Win7, because:
 * The code won't compile due to `base/synchronized.cc` which needs `CREATE_EVENT_MANUAL_RESET` introduced in Vista
 * Vista support lifecycle had ended, so it makes sense to move to Win 7.