### PR TITLE
Build break on configurations following the readme. zipconf.h cannot be found. #154

### DIFF
--- a/omaha/base/build.scons
+++ b/omaha/base/build.scons
@@ -239,6 +239,7 @@ cc_files += ['zlib/' +
 """ Add libzip library files."""
 
 libzip_src_path = '$THIRD_PARTY/libzip/lib/'
+libzip_src_xcode_path = '$THIRD_PARTY/libzip/xcode'
 libzip_src_path_dir = local_env.Dir(libzip_src_path)
 local_env.Dir('libzip').addRepository(libzip_src_path_dir)
 libzip_gladman_src_path = '$THIRD_PARTY/libzip/lib/gladman-fcrypt'
@@ -251,6 +252,7 @@ local_env.Append(
         'libzip/',
         libzip_gladman_src_path,
         libzip_src_path,
+        libzip_src_xcode_path,
         zlib_src_path,
     ],
     CCFLAGS=[

--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -523,6 +523,7 @@ win_env.AppendUnique(
         '$MAIN_DIR/third_party/chrome/files/src',
         '$THIRD_PARTY/breakpad/src',
         '$THIRD_PARTY/libzip/lib',
+        '$THIRD_PARTY/libzip/xcode',
     ],
 
     # Defines for windows environment.


### PR DESCRIPTION
Following the dev guide, after the master merge of 03/19, there is a build break due to failure to find headers. I believe this has to do with scons configurations.

This change fixes it for at least two contributors, but I don't know if it is the correct fix for any dev setup.

This addresses Issue #154