### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,14 +13,13 @@
 // limitations under the License.
 // ========================================================================
 
-.p4config
-BRANCH_OWNERS
+*.idb
+*.pdb
+*.pyc
 omaha/common/omaha_customization_proxy_clsid.h
 omaha/proxy_clsids.txt
-omaha/*.idb
 omaha/scons-out/**
+third_party/breakpad/**
+third_party/googletest/**
 third_party/libzip/**
 third_party/zlib/**
-
-# Ignore compiled Python files.
-*.pyc


### PR DESCRIPTION
It removes some extra Google noise and ignores breakpad and googletest directories which used to be submodules but now, they are not.