### PR TITLE
Remove DISALLOW_EVIL_CONSTRUCTORS macro

### DIFF
--- a/omaha/base/apply_tag.h
+++ b/omaha/base/apply_tag.h
@@ -86,7 +86,7 @@ class ApplyTag {
   // data with the tagged information.
   std::vector<byte> buffer_data_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(ApplyTag);
+  DISALLOW_COPY_AND_ASSIGN(ApplyTag);
 };
 
 }  // namespace omaha

--- a/omaha/base/atl_regexp.h
+++ b/omaha/base/atl_regexp.h
@@ -143,7 +143,7 @@ class AtlRE : public RE {
 
  private:
   mutable AtlRegExp re_;
-  DISALLOW_EVIL_CONSTRUCTORS(AtlRE);
+  DISALLOW_COPY_AND_ASSIGN(AtlRE);
 };
 
 }  // namespace omaha

--- a/omaha/base/atlconvfix.h
+++ b/omaha/base/atlconvfix.h
@@ -21,10 +21,10 @@
 #ifndef OMAHA_COMMON_ATLCONVFIX_H_
 #define OMAHA_COMMON_ATLCONVFIX_H_
 
-#ifndef DISALLOW_EVIL_CONSTRUCTORS
+#ifndef DISALLOW_COPY_AND_ASSIGN
 // A macro to disallow the evil copy constructor and operator= functions
 // This should be used in the private: declarations for a class
-#define DISALLOW_EVIL_CONSTRUCTORS(TypeName)    \
+#define DISALLOW_COPY_AND_ASSIGN(TypeName)    \
   TypeName(const TypeName&);                    \
   void operator=(const TypeName&)
 #endif
@@ -64,7 +64,7 @@ class DestroyBuffer : public ConversionClass<buffer_length> {
   }
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(DestroyBuffer);
+  DISALLOW_COPY_AND_ASSIGN(DestroyBuffer);
 };
 
 #define DECLARED_DESTROY_NAME(base_type) DestroyBuffer##base_type
@@ -82,7 +82,7 @@ class DestroyBuffer : public ConversionClass<buffer_length> {
                                                                code_page) { \
     } \
    private: \
-    DISALLOW_EVIL_CONSTRUCTORS(DECLARED_DESTROY_NAME(base_type##EX)); \
+    DISALLOW_COPY_AND_ASSIGN(DECLARED_DESTROY_NAME(base_type##EX)); \
   }; \
   typedef DECLARED_DESTROY_NAME(base_type##EX)<> \
       DECLARED_DESTROY_NAME(base_type)

--- a/omaha/base/command_line_parser.h
+++ b/omaha/base/command_line_parser.h
@@ -105,7 +105,7 @@ class CommandLineParser {
   scoped_ptr<internal::CommandLineParserArgs> required_args_;
   scoped_ptr<internal::CommandLineParserArgs> optional_args_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(CommandLineParser);
+  DISALLOW_COPY_AND_ASSIGN(CommandLineParser);
 };
 
 }  // namespace omaha

--- a/omaha/base/command_line_parser_internal.h
+++ b/omaha/base/command_line_parser_internal.h
@@ -67,7 +67,7 @@ class CommandLineParserArgs {
  private:
   SwitchAndArgumentsMap switch_arguments_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(CommandLineParserArgs);
+  DISALLOW_COPY_AND_ASSIGN(CommandLineParserArgs);
 };
 
 }  // namespace internal

--- a/omaha/base/command_line_validator.h
+++ b/omaha/base/command_line_validator.h
@@ -44,7 +44,7 @@ class CommandLineValidator {
     size_t num_required_parameters_;
 
    private:
-    DISALLOW_EVIL_CONSTRUCTORS(ScenarioParameter);
+    DISALLOW_COPY_AND_ASSIGN(ScenarioParameter);
   };
 
   typedef std::vector<ScenarioParameter*> ScenarioParameterVector;
@@ -97,7 +97,7 @@ class CommandLineValidator {
 
   size_t scenario_sequence_number_;
   MapScenarios scenarios_;
-  DISALLOW_EVIL_CONSTRUCTORS(CommandLineValidator);
+  DISALLOW_COPY_AND_ASSIGN(CommandLineValidator);
 };
 
 }  // namespace omaha

--- a/omaha/base/commands.h
+++ b/omaha/base/commands.h
@@ -105,7 +105,7 @@ class CommandParsingSimple {
 
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(CommandParsingSimple);
+  DISALLOW_COPY_AND_ASSIGN(CommandParsingSimple);
 };
 
 
@@ -151,7 +151,7 @@ class CommandParsing : public CommandParsingSimple {
   int options_count_;                 // Count of command-line options
   bool as_name_value_pair_;           // Parse as name-value-pair
 
-  DISALLOW_EVIL_CONSTRUCTORS(CommandParsing);
+  DISALLOW_COPY_AND_ASSIGN(CommandParsing);
 };
 
 }  // namespace omaha

--- a/omaha/base/debug.cc
+++ b/omaha/base/debug.cc
@@ -958,7 +958,7 @@ class SprintfCleaner {
   }
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(SprintfCleaner);
+  DISALLOW_COPY_AND_ASSIGN(SprintfCleaner);
 };
 
 static SprintfCleaner cleaner;

--- a/omaha/base/debug.h
+++ b/omaha/base/debug.h
@@ -134,7 +134,7 @@ class ReportIds : public GLock {
   bool LoadReportData(ReportData **data);
   void SaveReportData(ReportData *data);
 
-  DISALLOW_EVIL_CONSTRUCTORS(ReportIds);
+  DISALLOW_COPY_AND_ASSIGN(ReportIds);
 };
 
 #if defined(_DEBUG) || defined(ASSERT_IN_RELEASE)
@@ -257,7 +257,7 @@ class ReportSummaryGenerator {
   // get text summary of reports
   // caller is responsible for deleting the string returned
   TCHAR *GetReportSummary();
-  DISALLOW_EVIL_CONSTRUCTORS(ReportSummaryGenerator);
+  DISALLOW_COPY_AND_ASSIGN(ReportSummaryGenerator);
 };
 
 extern ReportSummaryGenerator g_report_summary_generator;

--- a/omaha/base/dynamic_link_kernel32.h
+++ b/omaha/base/dynamic_link_kernel32.h
@@ -38,7 +38,7 @@ class Kernel32 {
   static BOOL WINAPI IsWow64Process(HANDLE hProcess, PBOOL Wow64Process);
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(Kernel32);
+  DISALLOW_COPY_AND_ASSIGN(Kernel32);
 };
 
 }  // namespace omaha

--- a/omaha/base/file.h
+++ b/omaha/base/file.h
@@ -187,7 +187,7 @@ class File {
 
     static const int kMaxFileSize = kint32max;
 
-    DISALLOW_EVIL_CONSTRUCTORS(File);
+    DISALLOW_COPY_AND_ASSIGN(File);
 };
 
 // File lock
@@ -211,7 +211,7 @@ class FileLock {
  private:
   std::vector<HANDLE> handles_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(FileLock);
+  DISALLOW_COPY_AND_ASSIGN(FileLock);
 };
 
 
@@ -241,7 +241,7 @@ class FileWatcher : public StoreWatcher {
   bool watch_subtree_;
   DWORD notify_filter_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(FileWatcher);
+  DISALLOW_COPY_AND_ASSIGN(FileWatcher);
 };
 
 }  // namespace omaha

--- a/omaha/base/file_reader.h
+++ b/omaha/base/file_reader.h
@@ -52,7 +52,7 @@ class FileReader {
                                         // in on each read.
   bool is_unicode_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(FileReader);
+  DISALLOW_COPY_AND_ASSIGN(FileReader);
 };
 
 }  // namespace omaha

--- a/omaha/base/file_reader_unittest.cc
+++ b/omaha/base/file_reader_unittest.cc
@@ -135,7 +135,7 @@ class ReadingFilesTest : public testing::Test {
 
   CString temp_file_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(ReadingFilesTest);
+  DISALLOW_COPY_AND_ASSIGN(ReadingFilesTest);
 };
 
 

--- a/omaha/base/file_ver.h
+++ b/omaha/base/file_ver.h
@@ -65,7 +65,7 @@ class FileVer {
   // language charset
   DWORD   lang_charset_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(FileVer);
+  DISALLOW_COPY_AND_ASSIGN(FileVer);
 };
 
 }  // namespace omaha

--- a/omaha/base/logging.h
+++ b/omaha/base/logging.h
@@ -236,7 +236,7 @@ class LogWriter {
   bool Unregister();
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(LogWriter);
+  DISALLOW_COPY_AND_ASSIGN(LogWriter);
 };
 
 // A LogWriter that writes to a named file.
@@ -281,7 +281,7 @@ class FileLogWriter : public LogWriter {
 
   friend class FileLogWriterTest;
 
-  DISALLOW_EVIL_CONSTRUCTORS(FileLogWriter);
+  DISALLOW_COPY_AND_ASSIGN(FileLogWriter);
 };
 
 // A LogWriter that uses OutputDebugString() to write messages.
@@ -293,7 +293,7 @@ class OutputDebugStringLogWriter : public LogWriter {
   static OutputDebugStringLogWriter* Create();
   virtual void OutputMessage(const OutputInfo* info);
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(OutputDebugStringLogWriter);
+  DISALLOW_COPY_AND_ASSIGN(OutputDebugStringLogWriter);
 };
 
 // A LogWriter that overrides the settings in trconfig.ini and sends messages
@@ -314,7 +314,7 @@ class OverrideConfigLogWriter : public LogWriter {
   LogLevel level_;
   LogWriter* log_writer_;
   bool force_logging_enabled_;
-  DISALLOW_EVIL_CONSTRUCTORS(OverrideConfigLogWriter);
+  DISALLOW_COPY_AND_ASSIGN(OverrideConfigLogWriter);
 };
 
 // This log writer outputs to Event Tracing for Windows.
@@ -478,7 +478,7 @@ class Logging {
 
   friend class HistoryTest;
 
-  DISALLOW_EVIL_CONSTRUCTORS(Logging);
+  DISALLOW_COPY_AND_ASSIGN(Logging);
 };
 
 // In order to make the logging macro LC_LOG work out we need to pass a
@@ -515,7 +515,7 @@ class LoggingHelper {
   LogLevel level_;
   DWORD writer_mask_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(LoggingHelper);
+  DISALLOW_COPY_AND_ASSIGN(LoggingHelper);
 };
 
 // Getter for the Logging singleton class.

--- a/omaha/base/logging/logging.h
+++ b/omaha/base/logging/logging.h
@@ -462,7 +462,7 @@ class LogMessage {
   LogSeverity severity_;
   std::ostrstream stream_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(LogMessage);
+  DISALLOW_COPY_AND_ASSIGN(LogMessage);
 };
 
 // A non-macro interface to the log facility; (useful

--- a/omaha/base/object_factory.h
+++ b/omaha/base/object_factory.h
@@ -58,7 +58,7 @@ class Factory {
   typedef std::map<TypeId, ProductCreator> Map;
   Map id_to_creators_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(Factory);
+  DISALLOW_COPY_AND_ASSIGN(Factory);
 };
 
 }  // namespace omaha

--- a/omaha/base/proc_utils.h
+++ b/omaha/base/proc_utils.h
@@ -134,7 +134,7 @@ class ProcessTerminator {
   int session_id_;
 
   // Disable copy constructor and assignment operator.
-  DISALLOW_EVIL_CONSTRUCTORS(ProcessTerminator);
+  DISALLOW_COPY_AND_ASSIGN(ProcessTerminator);
 };
 
 // Application calling this function will be shut down

--- a/omaha/base/process.h
+++ b/omaha/base/process.h
@@ -311,7 +311,7 @@ class Process {
 #if !SHIPPING
   CString debug_info_;
 #endif
-  DISALLOW_EVIL_CONSTRUCTORS(Process);
+  DISALLOW_COPY_AND_ASSIGN(Process);
 };
 
 }  // namespace omaha

--- a/omaha/base/program_instance.h
+++ b/omaha/base/program_instance.h
@@ -35,7 +35,7 @@ namespace omaha {
     bool CheckSingleInstance();
     CString mutex_name_;
     auto_mutex mutex_;
-    DISALLOW_EVIL_CONSTRUCTORS(ProgramInstance);
+    DISALLOW_COPY_AND_ASSIGN(ProgramInstance);
   };
 
 }  // namespace omaha

--- a/omaha/base/queue_timer.h
+++ b/omaha/base/queue_timer.h
@@ -74,7 +74,7 @@ class QueueTimer {
     HANDLE timer_queue_;
     Callback callback_;
 
-    DISALLOW_EVIL_CONSTRUCTORS(QueueTimer);
+    DISALLOW_COPY_AND_ASSIGN(QueueTimer);
 };
 
 }  // namespace omaha

--- a/omaha/base/reactor.h
+++ b/omaha/base/reactor.h
@@ -84,7 +84,7 @@ class Reactor {
   CRITICAL_SECTION cs_;
   std::vector<RegistrationState*> handlers_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(Reactor);
+  DISALLOW_COPY_AND_ASSIGN(Reactor);
 };
 
 }  // namespace omaha

--- a/omaha/base/reg_key.h
+++ b/omaha/base/reg_key.h
@@ -420,7 +420,7 @@ class RegKey {
   // the HKEY for the current key
   HKEY h_key_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(RegKey);
+  DISALLOW_COPY_AND_ASSIGN(RegKey);
 };
 
 // Provides all the functionality of RegKey plus
@@ -455,7 +455,7 @@ class RegKeyWithChangeEvent : public RegKey {
 
  private:
   scoped_handle change_event_;
-  DISALLOW_EVIL_CONSTRUCTORS(RegKeyWithChangeEvent);
+  DISALLOW_COPY_AND_ASSIGN(RegKeyWithChangeEvent);
 };
 
 // Does the common things necessary for watching
@@ -489,7 +489,7 @@ class RegKeyWatcher : public StoreWatcher {
   bool watch_subtree_;
   DWORD notify_filter_;
   bool allow_creation_;
-  DISALLOW_EVIL_CONSTRUCTORS(RegKeyWatcher);
+  DISALLOW_COPY_AND_ASSIGN(RegKeyWatcher);
 };
 
 

--- a/omaha/base/registry_monitor_manager.cc
+++ b/omaha/base/registry_monitor_manager.cc
@@ -153,7 +153,7 @@ class KeyWatcher {
   RegistryKeyChangeCallback callback_;
   void* callback_param_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(KeyWatcher);
+  DISALLOW_COPY_AND_ASSIGN(KeyWatcher);
 };
 
 class RegistryMonitorImpl : public Runnable {
@@ -188,7 +188,7 @@ class RegistryMonitorImpl : public Runnable {
   Thread thread_;
   scoped_ptr<Gate> start_monitoring_gate_;
   scoped_event stop_monitoring_;
-  DISALLOW_EVIL_CONSTRUCTORS(RegistryMonitorImpl);
+  DISALLOW_COPY_AND_ASSIGN(RegistryMonitorImpl);
 };
 
 

--- a/omaha/base/registry_monitor_manager.h
+++ b/omaha/base/registry_monitor_manager.h
@@ -83,7 +83,7 @@ class RegistryMonitor {
  private:
   scoped_ptr<detail::RegistryMonitorImpl> impl_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(RegistryMonitor);
+  DISALLOW_COPY_AND_ASSIGN(RegistryMonitor);
 };
 
 }  // namespace omaha

--- a/omaha/base/service_utils.h
+++ b/omaha/base/service_utils.h
@@ -79,7 +79,7 @@ class ScmDatabase {
   static bool IsServiceMarkedDeleted(SC_HANDLE service);
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(ScmDatabase);
+  DISALLOW_COPY_AND_ASSIGN(ScmDatabase);
 };
 
 // Utility functions for the service's installation, overinstall etc.

--- a/omaha/base/shell.h
+++ b/omaha/base/shell.h
@@ -67,7 +67,7 @@ class Shell {
 
   static HRESULT BasicGetSpecialFolder(DWORD csidl, CString* folder_path);
 
-  DISALLOW_EVIL_CONSTRUCTORS(Shell);
+  DISALLOW_COPY_AND_ASSIGN(Shell);
 };
 
 }  // namespace omaha

--- a/omaha/base/shutdown_handler.h
+++ b/omaha/base/shutdown_handler.h
@@ -43,7 +43,7 @@ class ShutdownHandler : public EventHandler {
   scoped_event shutdown_event_;
   ShutdownCallback* shutdown_callback_;
   bool is_machine_;
-  DISALLOW_EVIL_CONSTRUCTORS(ShutdownHandler);
+  DISALLOW_COPY_AND_ASSIGN(ShutdownHandler);
 };
 
 }  // namespace omaha

--- a/omaha/base/smart_handle.h
+++ b/omaha/base/smart_handle.h
@@ -44,7 +44,7 @@ class BaseHandleTraitsT {
   }
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(BaseHandleTraitsT);
+  DISALLOW_COPY_AND_ASSIGN(BaseHandleTraitsT);
 };
 
 /**
@@ -122,7 +122,7 @@ class HandleT {
   T h_;
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(HandleT);
+  DISALLOW_COPY_AND_ASSIGN(HandleT);
 };
 
 
@@ -147,7 +147,7 @@ class HandleTraitsWin32Handle : public BaseHandleTraitsT<HANDLE> {
   }
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(HandleTraitsWin32Handle);
+  DISALLOW_COPY_AND_ASSIGN(HandleTraitsWin32Handle);
 };
 
 /*
@@ -166,7 +166,7 @@ class HandleTraitsFindHandle : public BaseHandleTraitsT<HANDLE> {
   }
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(HandleTraitsFindHandle);
+  DISALLOW_COPY_AND_ASSIGN(HandleTraitsFindHandle);
 };
 
 /*
@@ -180,7 +180,7 @@ class HandleTraitsHMenu : public BaseHandleTraitsT<HMENU> {
   }
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(HandleTraitsHMenu);
+  DISALLOW_COPY_AND_ASSIGN(HandleTraitsHMenu);
 };
 
 /*
@@ -193,7 +193,7 @@ class HandleTraitsHCryptKey : public BaseHandleTraitsT<HCRYPTKEY> {
   }
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(HandleTraitsHCryptKey);
+  DISALLOW_COPY_AND_ASSIGN(HandleTraitsHCryptKey);
 };
 
 /*
@@ -206,7 +206,7 @@ class HandleTraitsHCryptHash : public BaseHandleTraitsT<HCRYPTHASH> {
   }
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(HandleTraitsHCryptHash);
+  DISALLOW_COPY_AND_ASSIGN(HandleTraitsHCryptHash);
 };
 
 /*
@@ -219,7 +219,7 @@ class HandleTraitsLibrary : public BaseHandleTraitsT<HMODULE> {
   }
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(HandleTraitsLibrary);
+  DISALLOW_COPY_AND_ASSIGN(HandleTraitsLibrary);
 };
 
 

--- a/omaha/base/store_watcher.h
+++ b/omaha/base/store_watcher.h
@@ -51,7 +51,7 @@ class StoreWatcher {
   virtual HANDLE change_event() const = 0;
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(StoreWatcher);
+  DISALLOW_COPY_AND_ASSIGN(StoreWatcher);
 };
 
 }  // namespace omaha

--- a/omaha/base/synchronized.h
+++ b/omaha/base/synchronized.h
@@ -63,7 +63,7 @@ class AutoSync {
  private:
   const Lockable * lock_;
   bool first_time_;
-  DISALLOW_EVIL_CONSTRUCTORS(AutoSync);
+  DISALLOW_COPY_AND_ASSIGN(AutoSync);
 };
 
 // the usaage:
@@ -127,7 +127,7 @@ class GLock : public Lockable {
   CString name_;
 #endif
   mutable HANDLE mutex_;
-  DISALLOW_EVIL_CONSTRUCTORS(GLock);
+  DISALLOW_COPY_AND_ASSIGN(GLock);
 };
 
 // FakeGLock looks like a GLock, but none of its methods do anything.
@@ -146,7 +146,7 @@ class FakeGLock : public Lockable {
   virtual bool Unlock() const { return true; }
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(FakeGLock);
+  DISALLOW_COPY_AND_ASSIGN(FakeGLock);
 };
 
 // LLock stands for local lock.
@@ -166,7 +166,7 @@ class LLock : public Lockable {
 
  private:
   mutable CRITICAL_SECTION        critical_section_;
-  DISALLOW_EVIL_CONSTRUCTORS(LLock);
+  DISALLOW_COPY_AND_ASSIGN(LLock);
 };
 
 // A gate is a synchronization object used to either stop all
@@ -213,7 +213,7 @@ class Gate {
                                     int *selected_gate,
                                     bool wait_all);
   HANDLE gate_;
-  DISALLOW_EVIL_CONSTRUCTORS(Gate);
+  DISALLOW_COPY_AND_ASSIGN(Gate);
 };
 
 bool WaitAllowRepaint(const Gate& gate, DWORD msec);
@@ -228,7 +228,7 @@ class AutoGateKeeper {
   }
  private:
   Gate *gate_;
-  DISALLOW_EVIL_CONSTRUCTORS(AutoGateKeeper);
+  DISALLOW_COPY_AND_ASSIGN(AutoGateKeeper);
 };
 
 // A very simple rather fast lock - if uncontested.  USE ONLY AS A GLOBAL OBJECT
@@ -263,7 +263,7 @@ class AutoSimpleLock {
   ~AutoSimpleLock() { lock_.Unlock(); }
  private:
   const SimpleLock& lock_;
-  DISALLOW_EVIL_CONSTRUCTORS(AutoSimpleLock);
+  DISALLOW_COPY_AND_ASSIGN(AutoSimpleLock);
 };
 
 class AutoSimpleLockWithDelay {
@@ -273,7 +273,7 @@ class AutoSimpleLockWithDelay {
   ~AutoSimpleLockWithDelay() { lock_.Unlock(); }
  private:
   const SimpleLockWithDelay& lock_;
-  DISALLOW_EVIL_CONSTRUCTORS(AutoSimpleLockWithDelay);
+  DISALLOW_COPY_AND_ASSIGN(AutoSimpleLockWithDelay);
 };
 
 
@@ -290,7 +290,7 @@ class CriticalSection {
   CRITICAL_SECTION critical_section_;
   uint32 number_entries_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(CriticalSection);
+  DISALLOW_COPY_AND_ASSIGN(CriticalSection);
 };
 
 // A class that manages a CriticalSection with its lifetime, you pass
@@ -314,7 +314,7 @@ class SingleLock {
  private:
   CriticalSection * critical_section_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(SingleLock);
+  DISALLOW_COPY_AND_ASSIGN(SingleLock);
 };
 
 // Encapsulation for kernel Event. Initializes and destroys with it's lifetime
@@ -331,7 +331,7 @@ class EventObj {
  private:
   HANDLE h_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(EventObj);
+  DISALLOW_COPY_AND_ASSIGN(EventObj);
 };
 
 // Is the given handle signaled?

--- a/omaha/base/system.h
+++ b/omaha/base/system.h
@@ -175,7 +175,7 @@ class System {
     static HRESULT CreateChildOutputPipe(HANDLE* read, HANDLE* write);
 
   private:
-    DISALLOW_EVIL_CONSTRUCTORS(System);
+    DISALLOW_COPY_AND_ASSIGN(System);
 };
 
 }  // namespace omaha

--- a/omaha/base/thread.h
+++ b/omaha/base/thread.h
@@ -40,7 +40,7 @@ class Runnable {
   virtual ~Runnable() {}
   virtual void Run() = 0;
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(Runnable);
+  DISALLOW_COPY_AND_ASSIGN(Runnable);
 };
 
 // Any class devived from this one will be able to call
@@ -54,7 +54,7 @@ class ApcReceiver {
   virtual ~ApcReceiver() {}
   virtual void OnApc(ULONG_PTR param) = 0;
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(ApcReceiver);
+  DISALLOW_COPY_AND_ASSIGN(ApcReceiver);
 };
 
 // This class encapsulates win32 thread management functions.
@@ -87,7 +87,7 @@ class Thread {
   HANDLE    thread_;
   Gate start_gate_;     // Synchronizes the thread start.
 
-  DISALLOW_EVIL_CONSTRUCTORS(Thread);
+  DISALLOW_COPY_AND_ASSIGN(Thread);
 };
 
 }  // namespace omaha

--- a/omaha/base/thread_pool.cc
+++ b/omaha/base/thread_pool.cc
@@ -46,7 +46,7 @@ class Context {
   UserWorkItem* work_item_;
   const DWORD   coinit_flags_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(Context);
+  DISALLOW_COPY_AND_ASSIGN(Context);
 };
 
 }   // namespace

--- a/omaha/base/thread_pool.h
+++ b/omaha/base/thread_pool.h
@@ -43,7 +43,7 @@ class UserWorkItem {
   // and shutdown correctly. This event is set when the thread pool is closing.
   // Do not close this event as is owned by the thread pool.
   HANDLE shutdown_event_;
-  DISALLOW_EVIL_CONSTRUCTORS(UserWorkItem);
+  DISALLOW_COPY_AND_ASSIGN(UserWorkItem);
 };
 
 class ThreadPool {
@@ -81,7 +81,7 @@ class ThreadPool {
   // the thread pool is shutting down. The shutdown delay resolution is ~10ms.
   int shutdown_delay_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(ThreadPool);
+  DISALLOW_COPY_AND_ASSIGN(ThreadPool);
 };
 
 }  // namespace omaha

--- a/omaha/base/thread_pool_unittest.cc
+++ b/omaha/base/thread_pool_unittest.cc
@@ -33,7 +33,7 @@ class MyJob1 : public UserWorkItem {
  private:
   virtual void DoProcess() { ::InterlockedExchangeAdd(&g_completed_count, 1); }
 
-  DISALLOW_EVIL_CONSTRUCTORS(MyJob1);
+  DISALLOW_COPY_AND_ASSIGN(MyJob1);
 };
 
 // Increments the global count by 2.
@@ -44,7 +44,7 @@ class MyJob2 : public UserWorkItem {
  private:
   virtual void DoProcess() { ::InterlockedExchangeAdd(&g_completed_count, 2); }
 
-  DISALLOW_EVIL_CONSTRUCTORS(MyJob2);
+  DISALLOW_COPY_AND_ASSIGN(MyJob2);
 };
 
 // Increments the global count by 3.
@@ -55,7 +55,7 @@ class MyJob3 : public UserWorkItem {
  private:
   virtual void DoProcess() { ::InterlockedExchangeAdd(&g_completed_count, 3); }
 
-  DISALLOW_EVIL_CONSTRUCTORS(MyJob3);
+  DISALLOW_COPY_AND_ASSIGN(MyJob3);
 };
 
 // ThreadPool COM initialization test class. The class tests that the thread

--- a/omaha/base/timer.h
+++ b/omaha/base/timer.h
@@ -51,7 +51,7 @@ class LowResTimer {
   uint32 elapsed_;
   uint32 start_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(LowResTimer);
+  DISALLOW_COPY_AND_ASSIGN(LowResTimer);
 };
 
 inline double LowResTimer::GetSeconds() const {
@@ -115,7 +115,7 @@ class Timer {
 
   static time64 count_freq_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(Timer);
+  DISALLOW_COPY_AND_ASSIGN(Timer);
 };
 
 // lint -e{31}   Redefinition of symbol

--- a/omaha/base/utils.cc
+++ b/omaha/base/utils.cc
@@ -1038,7 +1038,7 @@ class BasicMessageHandlerInternal : public BasicMessageHandler,
     BasicMessageHandler::Process(msg);
   }
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(BasicMessageHandlerInternal);
+  DISALLOW_COPY_AND_ASSIGN(BasicMessageHandlerInternal);
 };
 
 

--- a/omaha/base/utils.h
+++ b/omaha/base/utils.h
@@ -561,7 +561,7 @@ class BasicMessageHandler : public MessageHandlerInterface {
   BasicMessageHandler() {}
   virtual void Process(MSG* msg);
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(BasicMessageHandler);
+  DISALLOW_COPY_AND_ASSIGN(BasicMessageHandler);
 };
 
 // An internal detail (used to handle messages
@@ -648,7 +648,7 @@ class MessageLoopWithWait : public MessageLoopInterface,
 
   // What to call when a handle is signaled.
   std::vector<WaitCallbackInterface*> callbacks_;
-  DISALLOW_EVIL_CONSTRUCTORS(MessageLoopWithWait);
+  DISALLOW_COPY_AND_ASSIGN(MessageLoopWithWait);
 };
 
 // This function calls ::SetDefaultDllDirectories to retrict DLL loads to either
@@ -795,7 +795,7 @@ class CallInterceptor {
 
  private:
   R* interceptor_;
-  DISALLOW_EVIL_CONSTRUCTORS(CallInterceptor);
+  DISALLOW_COPY_AND_ASSIGN(CallInterceptor);
 };
 
 // Gets a handle of the current process. The handle is a real handle

--- a/omaha/base/utils_unittest.cc
+++ b/omaha/base/utils_unittest.cc
@@ -377,7 +377,7 @@ class Counter {
   static int instance_count() { return instance_count_; }
  private:
   static int instance_count_;
-  DISALLOW_EVIL_CONSTRUCTORS(Counter);
+  DISALLOW_COPY_AND_ASSIGN(Counter);
 };
 
 int Counter::instance_count_ = 0;

--- a/omaha/base/wmi_query.h
+++ b/omaha/base/wmi_query.h
@@ -56,7 +56,7 @@ class WmiQuery {
   CComPtr<IWbemClassObject> obj_;
   bool at_end_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(WmiQuery);
+  DISALLOW_COPY_AND_ASSIGN(WmiQuery);
 };
 
 }  // namespace omaha

--- a/omaha/common/command_line_builder.h
+++ b/omaha/common/command_line_builder.h
@@ -146,7 +146,7 @@ class CommandLineBuilder {
   CString offline_dir_name_;
   CString session_id_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(CommandLineBuilder);
+  DISALLOW_COPY_AND_ASSIGN(CommandLineBuilder);
 };
 
 }  // namespace omaha

--- a/omaha/common/config_manager.h
+++ b/omaha/common/config_manager.h
@@ -311,7 +311,7 @@ class ConfigManager {
   bool is_running_from_official_user_dir_;
   bool is_running_from_official_machine_dir_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(ConfigManager);
+  DISALLOW_COPY_AND_ASSIGN(ConfigManager);
 };
 
 }  // namespace omaha

--- a/omaha/common/event_logger.h
+++ b/omaha/common/event_logger.h
@@ -142,7 +142,7 @@ class GoogleUpdateLogEvent {
   int id_;
   bool is_machine_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(GoogleUpdateLogEvent);
+  DISALLOW_COPY_AND_ASSIGN(GoogleUpdateLogEvent);
 };
 
 }  // namespace omaha

--- a/omaha/common/extra_args_parser.h
+++ b/omaha/common/extra_args_parser.h
@@ -49,7 +49,7 @@ class ExtraArgsParser {
   CommandLineAppArgs cur_extra_app_args_;
   bool first_app_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(ExtraArgsParser);
+  DISALLOW_COPY_AND_ASSIGN(ExtraArgsParser);
 };
 
 }  // namespace omaha

--- a/omaha/common/goopdate_command_line_validator.h
+++ b/omaha/common/goopdate_command_line_validator.h
@@ -89,7 +89,7 @@ class GoopdateCommandLineValidator {
   scoped_ptr<CommandLineValidator> validator_;
   MapScenarioHandlers scenario_handlers_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(GoopdateCommandLineValidator);
+  DISALLOW_COPY_AND_ASSIGN(GoopdateCommandLineValidator);
 };
 
 }  // namespace omaha

--- a/omaha/core/core.h
+++ b/omaha/core/core.h
@@ -123,7 +123,7 @@ class Core
 
   friend class CoreUtilsTest;
 
-  DISALLOW_EVIL_CONSTRUCTORS(Core);
+  DISALLOW_COPY_AND_ASSIGN(Core);
 };
 
 }  // namespace omaha

--- a/omaha/core/core_unittest.cc
+++ b/omaha/core/core_unittest.cc
@@ -53,7 +53,7 @@ class CoreRunner : public Runnable {
   }
 
   bool is_machine_;
-  DISALLOW_EVIL_CONSTRUCTORS(CoreRunner);
+  DISALLOW_COPY_AND_ASSIGN(CoreRunner);
 };
 
 }  // namespace

--- a/omaha/core/google_update_core.h
+++ b/omaha/core/google_update_core.h
@@ -62,7 +62,7 @@ class ATL_NO_VTABLE GoogleUpdateCoreBase
 
   friend class GoogleUpdateCoreTest;
 
-  DISALLOW_EVIL_CONSTRUCTORS(GoogleUpdateCoreBase);
+  DISALLOW_COPY_AND_ASSIGN(GoogleUpdateCoreBase);
 };
 
 template <bool is_service>
@@ -93,8 +93,7 @@ class ATL_NO_VTABLE GoogleUpdateCore
   END_REGISTRY_MAP()
 
  private:
-
-  DISALLOW_EVIL_CONSTRUCTORS(GoogleUpdateCore);
+  DISALLOW_COPY_AND_ASSIGN(GoogleUpdateCore);
 };
 
 typedef GoogleUpdateCore<false> GoogleUpdateCoreMachine;

--- a/omaha/core/scheduler.h
+++ b/omaha/core/scheduler.h
@@ -54,7 +54,7 @@ class Scheduler {
   // the value of the timer is read when the alarm goes off.
   scoped_ptr<HighresTimer> cr_debug_timer_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(Scheduler);
+  DISALLOW_COPY_AND_ASSIGN(Scheduler);
 };
 
 }  // namespace omaha

--- a/omaha/core/system_monitor.h
+++ b/omaha/core/system_monitor.h
@@ -89,7 +89,7 @@ class SystemMonitor
   bool is_machine_;
   SystemMonitorObserver* observer_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(SystemMonitor);
+  DISALLOW_COPY_AND_ASSIGN(SystemMonitor);
 };
 
 }  // namespace omaha

--- a/omaha/goopdate/application_usage_data.h
+++ b/omaha/goopdate/application_usage_data.h
@@ -77,7 +77,7 @@ class ApplicationUsageData {
   bool check_low_integrity_;   // Whether to check the low integrity registry
                                // location.
 
-  DISALLOW_EVIL_CONSTRUCTORS(ApplicationUsageData);
+  DISALLOW_COPY_AND_ASSIGN(ApplicationUsageData);
 };
 
 }  // namespace omaha

--- a/omaha/goopdate/download_manager.h
+++ b/omaha/goopdate/download_manager.h
@@ -111,7 +111,7 @@ class DownloadManager : public DownloadManagerInterface {
 
     scoped_ptr<NetworkRequest> network_request_;
 
-    DISALLOW_EVIL_CONSTRUCTORS(State);
+    DISALLOW_COPY_AND_ASSIGN(State);
   };
 
   // Creates a download state corresponding to the app. The state object is
@@ -154,7 +154,7 @@ class DownloadManager : public DownloadManagerInterface {
   scoped_ptr<PackageCache> package_cache_;
 
   friend class DownloadManagerTest;
-  DISALLOW_EVIL_CONSTRUCTORS(DownloadManager);
+  DISALLOW_COPY_AND_ASSIGN(DownloadManager);
 };
 
 }  // namespace omaha

--- a/omaha/goopdate/download_manager_unittest.cc
+++ b/omaha/goopdate/download_manager_unittest.cc
@@ -81,7 +81,7 @@ class DownloadAppWorkItem : public UserWorkItem {
   DownloadManager* download_manager_;
   App* app_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(DownloadAppWorkItem);
+  DISALLOW_COPY_AND_ASSIGN(DownloadAppWorkItem);
 };
 
 bool FileHashesEqual(const FileHash& hash1, const FileHash& hash2) {

--- a/omaha/goopdate/google_update.h
+++ b/omaha/goopdate/google_update.h
@@ -98,7 +98,7 @@ class GoogleUpdate : public CAtlExeModuleT<GoogleUpdate> {
   bool is_machine_;
   ComServerMode mode_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(GoogleUpdate);
+  DISALLOW_COPY_AND_ASSIGN(GoogleUpdate);
 };
 
 }  // namespace omaha

--- a/omaha/goopdate/goopdate.cc
+++ b/omaha/goopdate/goopdate.cc
@@ -306,7 +306,7 @@ class GoopdateImpl {
 
   Goopdate* goopdate_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(GoopdateImpl);
+  DISALLOW_COPY_AND_ASSIGN(GoopdateImpl);
 };
 
 GoopdateImpl::GoopdateImpl(Goopdate* goopdate, bool is_local_system)

--- a/omaha/goopdate/goopdate.h
+++ b/omaha/goopdate/goopdate.h
@@ -61,7 +61,7 @@ class Goopdate {
   // Uses pimpl idiom to minimize dependencies on implementation details.
   scoped_ptr<detail::GoopdateImpl> impl_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(Goopdate);
+  DISALLOW_COPY_AND_ASSIGN(Goopdate);
 };
 
 }  // namespace omaha

--- a/omaha/goopdate/process_launcher.h
+++ b/omaha/goopdate/process_launcher.h
@@ -95,7 +95,7 @@ class ATL_NO_VTABLE ProcessLauncher
                              ULONG_PTR* stdout_handle);
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(ProcessLauncher);
+  DISALLOW_COPY_AND_ASSIGN(ProcessLauncher);
 };
 
 }  // namespace omaha

--- a/omaha/goopdate/resource_manager.h
+++ b/omaha/goopdate/resource_manager.h
@@ -85,7 +85,7 @@ class ResourceManager {
 
   friend class ResourceManagerTest;
 
-  DISALLOW_EVIL_CONSTRUCTORS(ResourceManager);
+  DISALLOW_COPY_AND_ASSIGN(ResourceManager);
 };
 
 }  // namespace omaha

--- a/omaha/goopdate/string_formatter.h
+++ b/omaha/goopdate/string_formatter.h
@@ -37,7 +37,7 @@ class StringFormatter {
  private:
   CString language_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(StringFormatter);
+  DISALLOW_COPY_AND_ASSIGN(StringFormatter);
 };
 
 }  // namespace omaha

--- a/omaha/net/bits_job_callback.h
+++ b/omaha/net/bits_job_callback.h
@@ -57,7 +57,7 @@ class ATL_NO_VTABLE BitsJobCallback
   BitsRequest* bits_request_;
   LLock lock_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(BitsJobCallback);
+  DISALLOW_COPY_AND_ASSIGN(BitsJobCallback);
 };
 
 }   // namespace omaha

--- a/omaha/net/bits_request.h
+++ b/omaha/net/bits_request.h
@@ -266,7 +266,7 @@ class BitsRequest : public HttpRequestInterface {
   // BitsRequest.
   static const int kJobProgressReportMinimumIntervalMs = 200;
 
-  DISALLOW_EVIL_CONSTRUCTORS(BitsRequest);
+  DISALLOW_COPY_AND_ASSIGN(BitsRequest);
 };
 
 }   // namespace omaha

--- a/omaha/net/detector.h
+++ b/omaha/net/detector.h
@@ -43,7 +43,7 @@ class RegistryOverrideProxyDetector : public ProxyDetectorInterface {
   virtual const TCHAR* source() { return _T("RegistryOverride"); }
  private:
   CString reg_path_;
-  DISALLOW_EVIL_CONSTRUCTORS(RegistryOverrideProxyDetector);
+  DISALLOW_COPY_AND_ASSIGN(RegistryOverrideProxyDetector);
 };
 
 class UpdateDevProxyDetector : public ProxyDetectorInterface {
@@ -55,7 +55,7 @@ class UpdateDevProxyDetector : public ProxyDetectorInterface {
   virtual const TCHAR* source() { return _T("UpdateDev"); }
  private:
   RegistryOverrideProxyDetector registry_detector_;
-  DISALLOW_EVIL_CONSTRUCTORS(UpdateDevProxyDetector);
+  DISALLOW_COPY_AND_ASSIGN(UpdateDevProxyDetector);
 };
 
 // A version that picks up proxy override from a group policy.
@@ -78,7 +78,7 @@ class DefaultProxyDetector : public ProxyDetectorInterface {
   virtual HRESULT Detect(ProxyConfig* config);
   virtual const TCHAR* source() { return _T("winhttp"); }
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(DefaultProxyDetector);
+  DISALLOW_COPY_AND_ASSIGN(DefaultProxyDetector);
 };
 
 // Detects proxy information for Firefox.
@@ -126,7 +126,7 @@ class FirefoxProxyDetector : public ProxyDetectorInterface {
   scoped_ptr<ProxyConfig> cached_config_;
 
   friend class FirefoxProxyDetectorTest;
-  DISALLOW_EVIL_CONSTRUCTORS(FirefoxProxyDetector);
+  DISALLOW_COPY_AND_ASSIGN(FirefoxProxyDetector);
 };
 
 namespace internal {
@@ -140,7 +140,7 @@ class IEProxyDetector : public ProxyDetectorInterface {
   virtual HRESULT Detect(ProxyConfig* config);
   virtual const TCHAR* source() { return _T("IE"); }
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(IEProxyDetector);
+  DISALLOW_COPY_AND_ASSIGN(IEProxyDetector);
 };
 
 }  // namespace internal

--- a/omaha/net/detector_unittest.cc
+++ b/omaha/net/detector_unittest.cc
@@ -85,7 +85,7 @@ class FirefoxProxyDetectorTest : public testing::Test {
   scoped_ptr<FirefoxProxyDetector> detector_;
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(FirefoxProxyDetectorTest);
+  DISALLOW_COPY_AND_ASSIGN(FirefoxProxyDetectorTest);
 };
 
 bool FirefoxProxyDetectorTest::BuildPrefsFile(const CString& type,
@@ -357,7 +357,7 @@ class GroupPolicyProxyDetectorTest : public testing::TestWithParam<bool>  {
   scoped_ptr<GroupPolicyProxyDetector> detector_;
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(GroupPolicyProxyDetectorTest);
+  DISALLOW_COPY_AND_ASSIGN(GroupPolicyProxyDetectorTest);
 };
 
 const TCHAR kGpoSourceString[] = _T("GroupPolicy");

--- a/omaha/net/http_client.h
+++ b/omaha/net/http_client.h
@@ -351,7 +351,7 @@ class HttpClient {
   }
 
   static Factory* factory_;
-  DISALLOW_EVIL_CONSTRUCTORS(HttpClient);
+  DISALLOW_COPY_AND_ASSIGN(HttpClient);
 };
 
 // Creates an http client, depending on what is available on the platform.

--- a/omaha/net/network_config.h
+++ b/omaha/net/network_config.h
@@ -272,7 +272,7 @@ class NetworkConfig {
   ProxyAuth proxy_auth_;
 
   friend class NetworkConfigManager;
-  DISALLOW_EVIL_CONSTRUCTORS(NetworkConfig);
+  DISALLOW_COPY_AND_ASSIGN(NetworkConfig);
 };
 
 class NetworkConfigManager {
@@ -307,7 +307,7 @@ class NetworkConfigManager {
   static LLock instance_lock_;
   static bool is_machine_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(NetworkConfigManager);
+  DISALLOW_COPY_AND_ASSIGN(NetworkConfigManager);
 };
 
 }   // namespace omaha

--- a/omaha/net/network_request.h
+++ b/omaha/net/network_request.h
@@ -187,7 +187,7 @@ class NetworkRequest {
  private:
   // Uses pimpl idiom to minimize dependencies on implementation details.
   scoped_ptr<internal::NetworkRequestImpl> impl_;
-  DISALLOW_EVIL_CONSTRUCTORS(NetworkRequest);
+  DISALLOW_COPY_AND_ASSIGN(NetworkRequest);
 };
 
 }   // namespace omaha

--- a/omaha/net/network_request_impl.h
+++ b/omaha/net/network_request_impl.h
@@ -227,7 +227,7 @@ class NetworkRequestImpl {
   static const int kTimeBetweenRetriesMultiplier     = 2;
   static const int kDefaultRetryTimeJitterMs         = 3000;    // +- 3 seconds.
 
-  DISALLOW_EVIL_CONSTRUCTORS(NetworkRequestImpl);
+  DISALLOW_COPY_AND_ASSIGN(NetworkRequestImpl);
 };
 
 

--- a/omaha/net/proxy_auth.h
+++ b/omaha/net/proxy_auth.h
@@ -107,7 +107,7 @@ class ProxyAuth {
   bool ReadFromPreIE7(const CString& server);
   bool PromptUser(const CString& server, const ProxyAuthConfig& config);
 
-  DISALLOW_EVIL_CONSTRUCTORS(ProxyAuth);
+  DISALLOW_COPY_AND_ASSIGN(ProxyAuth);
 };
 
 }  // namespace omaha

--- a/omaha/net/winhttp.cc
+++ b/omaha/net/winhttp.cc
@@ -140,7 +140,7 @@ class WinHttp : public HttpClient {
   static WinHttpVTable winhttp_;
   static LLock lock_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(WinHttp);
+  DISALLOW_COPY_AND_ASSIGN(WinHttp);
 };
 
 WinHttpVTable WinHttp::winhttp_;

--- a/omaha/net/winhttp_vtable.h
+++ b/omaha/net/winhttp_vtable.h
@@ -140,7 +140,7 @@ class WinHttpVTable {
 
   HINSTANCE library_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(WinHttpVTable);
+  DISALLOW_COPY_AND_ASSIGN(WinHttpVTable);
 };
 
 #define PROTECT_WRAP(function, proto, call, result_type, result_error_value)  \

--- a/omaha/service/service_main.h
+++ b/omaha/service/service_main.h
@@ -505,7 +505,7 @@ class ServiceModule
   // Time to wait before performing the specified action.
   static const DWORD kActionDelayMs       = 1000L * 60 * 15;  // 15 minutes.
 
-  DISALLOW_EVIL_CONSTRUCTORS(ServiceModule);
+  DISALLOW_COPY_AND_ASSIGN(ServiceModule);
 };
 
 #pragma warning(pop)

--- a/omaha/setup/setup.h
+++ b/omaha/setup/setup.h
@@ -194,7 +194,7 @@ class Setup {
 
   friend class SetupTest;
   friend class SetupOfflineInstallerTest;
-  DISALLOW_EVIL_CONSTRUCTORS(Setup);
+  DISALLOW_COPY_AND_ASSIGN(Setup);
 };
 
 }  // namespace omaha

--- a/omaha/setup/setup_files.h
+++ b/omaha/setup/setup_files.h
@@ -88,7 +88,7 @@ class SetupFiles {
 
   friend class SetupFilesTest;
 
-  DISALLOW_EVIL_CONSTRUCTORS(SetupFiles);
+  DISALLOW_COPY_AND_ASSIGN(SetupFiles);
 };
 
 }  // namespace omaha

--- a/omaha/setup/setup_google_update.h
+++ b/omaha/setup/setup_google_update.h
@@ -111,7 +111,7 @@ class SetupGoogleUpdate {
   friend class SetupGoogleUpdateTest;
   friend class AppManagerTestBase;
 
-  DISALLOW_EVIL_CONSTRUCTORS(SetupGoogleUpdate);
+  DISALLOW_COPY_AND_ASSIGN(SetupGoogleUpdate);
 };
 
 }  // namespace omaha

--- a/omaha/statsreport/aggregator-win32.h
+++ b/omaha/statsreport/aggregator-win32.h
@@ -78,7 +78,7 @@ private:
   /// Specifies HKLM or HKCU, respectively.
   bool is_machine_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(MetricsAggregatorWin32);
+  DISALLOW_COPY_AND_ASSIGN(MetricsAggregatorWin32);
 };
 
 } // namespace stats_report

--- a/omaha/statsreport/aggregator.h
+++ b/omaha/statsreport/aggregator.h
@@ -50,7 +50,7 @@ protected:
   virtual void Aggregate(BoolMetric &metric) = 0;
 
 private:
-  DISALLOW_EVIL_CONSTRUCTORS(MetricsAggregator);
+  DISALLOW_COPY_AND_ASSIGN(MetricsAggregator);
 
   const MetricCollection &coll_;
 };

--- a/omaha/statsreport/formatter.h
+++ b/omaha/statsreport/formatter.h
@@ -50,7 +50,7 @@ public:
   const char *output() { output_ << std::ends; return output_.str(); }
 
 private:
-  DISALLOW_EVIL_CONSTRUCTORS(Formatter);
+  DISALLOW_COPY_AND_ASSIGN(Formatter);
 
   mutable std::strstream output_;
 };

--- a/omaha/statsreport/metrics.cc
+++ b/omaha/statsreport/metrics.cc
@@ -50,7 +50,7 @@ public:
 
 private:
   MetricBase const *const metric_;
-  DISALLOW_EVIL_CONSTRUCTORS(MetricBase::ObjectLock);
+  DISALLOW_COPY_AND_ASSIGN(MetricBase::ObjectLock);
 };
 
 void MetricBase::Lock() const {

--- a/omaha/statsreport/metrics.h
+++ b/omaha/statsreport/metrics.h
@@ -166,7 +166,7 @@ protected:
   MetricCollectionBase *const coll_;
 
 private:
-  DISALLOW_EVIL_CONSTRUCTORS(MetricBase);
+  DISALLOW_COPY_AND_ASSIGN(MetricBase);
 };
 
 /// Must be a POD
@@ -212,7 +212,7 @@ private:
   using MetricCollectionBase::initialized_;
   using MetricCollectionBase::first_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(MetricCollection);
+  DISALLOW_COPY_AND_ASSIGN(MetricCollection);
 
   /// MetricBase is intimate with us
   friend class MetricBase;
@@ -296,7 +296,7 @@ protected:
   int64 value_;
 
 private:
-  DISALLOW_EVIL_CONSTRUCTORS(IntegerMetricBase);
+  DISALLOW_COPY_AND_ASSIGN(IntegerMetricBase);
 };
 
 /// A count metric is a cumulative counter of events.
@@ -314,7 +314,7 @@ public:
   int64 Reset();
 
 private:
-  DISALLOW_EVIL_CONSTRUCTORS(CountMetric);
+  DISALLOW_COPY_AND_ASSIGN(CountMetric);
 };
 
 class TimingMetric: public MetricBase {
@@ -362,7 +362,7 @@ public:
   TimingData Reset();
 
 private:
-  DISALLOW_EVIL_CONSTRUCTORS(TimingMetric);
+  DISALLOW_COPY_AND_ASSIGN(TimingMetric);
 
   void Clear();
 
@@ -414,7 +414,7 @@ private:
   /// The item count we divide the captured time by
   uint32 count_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(TimingSample);
+  DISALLOW_COPY_AND_ASSIGN(TimingSample);
 };
 
 /// An integer metric is used to sample values that vary over time.
@@ -436,7 +436,7 @@ public:
   void operator -= (int64 sub)    { Subtract(sub); }
 
 private:
-  DISALLOW_EVIL_CONSTRUCTORS(IntegerMetric);
+  DISALLOW_COPY_AND_ASSIGN(IntegerMetric);
 };
 
 /// A bool metric is tri-state, and can be:
@@ -486,7 +486,7 @@ public:
   TristateBoolValue value() const { return value_; };
 
 private:
-  DISALLOW_EVIL_CONSTRUCTORS(BoolMetric);
+  DISALLOW_COPY_AND_ASSIGN(BoolMetric);
 
   TristateBoolValue value_;
 };

--- a/omaha/testing/unittest_debug_helper.h
+++ b/omaha/testing/unittest_debug_helper.h
@@ -52,7 +52,7 @@ class UseAssertFunction {
 
  private:
   DebugAssertFunctionType *old_function_;
-  DISALLOW_EVIL_CONSTRUCTORS(UseAssertFunction);
+  DISALLOW_COPY_AND_ASSIGN(UseAssertFunction);
 };
 
 
@@ -78,7 +78,7 @@ class FailOnAssert {
 
  private:
   UseAssertFunction inner_;
-  DISALLOW_EVIL_CONSTRUCTORS(FailOnAssert);
+  DISALLOW_COPY_AND_ASSIGN(FailOnAssert);
 };
 
 // A class with no methods which will cause asserts to be ignored;
@@ -102,7 +102,7 @@ class IgnoreAsserts {
 
  private:
   UseAssertFunction inner_;
-  DISALLOW_EVIL_CONSTRUCTORS(IgnoreAsserts);
+  DISALLOW_COPY_AND_ASSIGN(IgnoreAsserts);
 };
 
 // A class with no methods which will cause asserts to be counted but otherwise
@@ -140,7 +140,7 @@ class ExpectAsserts {
 
   UseAssertFunction inner_;
   int old_assert_count_;
-  DISALLOW_EVIL_CONSTRUCTORS(ExpectAsserts);
+  DISALLOW_COPY_AND_ASSIGN(ExpectAsserts);
 };
 
 }  // namespace omaha

--- a/omaha/third_party/chrome/files/src/base/basictypes.h
+++ b/omaha/third_party/chrome/files/src/base/basictypes.h
@@ -84,13 +84,6 @@ const  int64 kint64max  = (( int64) GG_LONGLONG(0x7FFFFFFFFFFFFFFF));
   TypeName(const TypeName&);               \
   void operator=(const TypeName&)
 
-// An older, deprecated, politically incorrect name for the above.
-// NOTE: The usage of this macro was baned from our code base, but some
-// third_party libraries are yet using it.
-// TODO(tfarina): Figure out how to fix the usage of this macro in the
-// third_party libraries and get rid of it.
-#define DISALLOW_EVIL_CONSTRUCTORS(TypeName) DISALLOW_COPY_AND_ASSIGN(TypeName)
-
 // A macro to disallow all the implicit constructors, namely the
 // default constructor, copy constructor and operator= functions.
 //

--- a/omaha/tools/goopdump/data_dumper.h
+++ b/omaha/tools/goopdump/data_dumper.h
@@ -53,7 +53,7 @@ class DataDumper {
                                 RegKey* key,
                                 const int indent);
 
-  DISALLOW_EVIL_CONSTRUCTORS(DataDumper);
+  DISALLOW_COPY_AND_ASSIGN(DataDumper);
 };
 
 class DumpHeader {
@@ -63,7 +63,7 @@ class DumpHeader {
 
  private:
   const DumpLog& dump_log_;
-  DISALLOW_EVIL_CONSTRUCTORS(DumpHeader);
+  DISALLOW_COPY_AND_ASSIGN(DumpHeader);
 };
 
 }  // namespace omaha

--- a/omaha/tools/goopdump/data_dumper_app_manager.h
+++ b/omaha/tools/goopdump/data_dumper_app_manager.h
@@ -39,7 +39,7 @@ class DataDumperAppManager : public DataDumper {
                           const AppManager& app_manager);
   void DumpRawRegistryData(const DumpLog& dump_log, bool is_machine);
 
-  DISALLOW_EVIL_CONSTRUCTORS(DataDumperAppManager);
+  DISALLOW_COPY_AND_ASSIGN(DataDumperAppManager);
 };
 
 }  // namespace omaha

--- a/omaha/tools/goopdump/data_dumper_goopdate.h
+++ b/omaha/tools/goopdump/data_dumper_goopdate.h
@@ -52,7 +52,7 @@ class DataDumperGoopdate : public DataDumper {
                         int num_tail_lines);
 
 
-  DISALLOW_EVIL_CONSTRUCTORS(DataDumperGoopdate);
+  DISALLOW_COPY_AND_ASSIGN(DataDumperGoopdate);
 };
 
 }  // namespace omaha

--- a/omaha/tools/goopdump/data_dumper_network.h
+++ b/omaha/tools/goopdump/data_dumper_network.h
@@ -35,7 +35,7 @@ class DataDumperNetwork : public DataDumper {
  private:
   void DumpNetworkConfig(const DumpLog& dump_log);
 
-  DISALLOW_EVIL_CONSTRUCTORS(DataDumperNetwork);
+  DISALLOW_COPY_AND_ASSIGN(DataDumperNetwork);
 };
 
 }  // namespace omaha

--- a/omaha/tools/goopdump/data_dumper_oneclick.h
+++ b/omaha/tools/goopdump/data_dumper_oneclick.h
@@ -36,7 +36,7 @@ class DataDumperOneClick : public DataDumper {
  private:
   void DumpOneClickDataForVersion(const DumpLog& dump_log, int plugin_version);
 
-  DISALLOW_EVIL_CONSTRUCTORS(DataDumperOneClick);
+  DISALLOW_COPY_AND_ASSIGN(DataDumperOneClick);
 };
 
 }  // namespace omaha

--- a/omaha/tools/goopdump/data_dumper_osdata.h
+++ b/omaha/tools/goopdump/data_dumper_osdata.h
@@ -34,7 +34,7 @@ class DataDumperOSData : public DataDumper {
 
  private:
   HRESULT GetSystemUptime(CString* uptime);
-  DISALLOW_EVIL_CONSTRUCTORS(DataDumperOSData);
+  DISALLOW_COPY_AND_ASSIGN(DataDumperOSData);
 };
 
 }  // namespace omaha

--- a/omaha/tools/goopdump/dump_log.h
+++ b/omaha/tools/goopdump/dump_log.h
@@ -33,7 +33,7 @@ class DumpLogHandler {
   virtual void WriteLine(const TCHAR* line) = 0;
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(DumpLogHandler);
+  DISALLOW_COPY_AND_ASSIGN(DumpLogHandler);
 };
 
 class ConsoleDumpLogHandler : public DumpLogHandler {
@@ -44,7 +44,7 @@ class ConsoleDumpLogHandler : public DumpLogHandler {
   virtual void WriteLine(const TCHAR* line);
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(ConsoleDumpLogHandler);
+  DISALLOW_COPY_AND_ASSIGN(ConsoleDumpLogHandler);
 };
 
 class DebugDumpLogHandler : public DumpLogHandler {
@@ -55,7 +55,7 @@ class DebugDumpLogHandler : public DumpLogHandler {
   virtual void WriteLine(const TCHAR* line);
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(DebugDumpLogHandler);
+  DISALLOW_COPY_AND_ASSIGN(DebugDumpLogHandler);
 };
 
 class FileDumpLogHandler : public DumpLogHandler {
@@ -70,7 +70,7 @@ class FileDumpLogHandler : public DumpLogHandler {
   void WriteBufToFile(const void* buf, DWORD num_bytes_to_write);
 
   CString filename_;
-  DISALLOW_EVIL_CONSTRUCTORS(FileDumpLogHandler);
+  DISALLOW_COPY_AND_ASSIGN(FileDumpLogHandler);
 };
 
 
@@ -103,7 +103,7 @@ class DumpLog {
   ConsoleDumpLogHandler console_handler_;
   DebugDumpLogHandler debug_handler_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(DumpLog);
+  DISALLOW_COPY_AND_ASSIGN(DumpLog);
 };
 
 }  // namespace omaha

--- a/omaha/tools/goopdump/goopdump.cc
+++ b/omaha/tools/goopdump/goopdump.cc
@@ -55,7 +55,7 @@ class GoopdateProcessMonitorCallback : public ProcessMonitorCallbackInterface {
  private:
   const DumpLog& dump_log_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(GoopdateProcessMonitorCallback);
+  DISALLOW_COPY_AND_ASSIGN(GoopdateProcessMonitorCallback);
 };
 
 

--- a/omaha/tools/goopdump/goopdump.h
+++ b/omaha/tools/goopdump/goopdump.h
@@ -56,7 +56,7 @@ class Goopdump {
   GoopdumpCmdLineArgs args_;
   DumpLog dump_log_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(Goopdump);
+  DISALLOW_COPY_AND_ASSIGN(Goopdump);
 };
 
 }  // namespace omaha

--- a/omaha/tools/goopdump/process_monitor.h
+++ b/omaha/tools/goopdump/process_monitor.h
@@ -46,7 +46,7 @@ class ProcessMonitorCallbackInterface {
   virtual void OnProcessRemoved(DWORD process_id) = 0;
 
  private:
-  DISALLOW_EVIL_CONSTRUCTORS(ProcessMonitorCallbackInterface);
+  DISALLOW_COPY_AND_ASSIGN(ProcessMonitorCallbackInterface);
 };
 
 // This class creates a thread to monitor running processes for particular
@@ -101,7 +101,7 @@ class ProcessMonitor {
   scoped_handle event_thread_exit_;   // Signal to exit monitor_thread_.
   scoped_handle monitor_thread_;      // Handle to the monitoring thread.
 
-  DISALLOW_EVIL_CONSTRUCTORS(ProcessMonitor);
+  DISALLOW_COPY_AND_ASSIGN(ProcessMonitor);
 };
 
 }  // namespace omaha

--- a/omaha/tools/goopdump/process_monitor_unittest.cc
+++ b/omaha/tools/goopdump/process_monitor_unittest.cc
@@ -57,7 +57,7 @@ class MockProcessMonitorCallback : public ProcessMonitorCallbackInterface {
   std::vector<DWORD> process_ids_added_;
   std::vector<DWORD> process_ids_removed_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(MockProcessMonitorCallback);
+  DISALLOW_COPY_AND_ASSIGN(MockProcessMonitorCallback);
 };
 
 TEST(GoopdumpProcessMonitorTest, TestStartStopNoop) {

--- a/omaha/ui/complete_wnd.h
+++ b/omaha/ui/complete_wnd.h
@@ -80,7 +80,7 @@ class CompleteWnd : public OmahaWnd {
   CompleteWndEvents* events_sink_;
   const DWORD control_classes_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(CompleteWnd);
+  DISALLOW_COPY_AND_ASSIGN(CompleteWnd);
 };
 
 }  // namespace omaha

--- a/omaha/ui/progress_wnd.h
+++ b/omaha/ui/progress_wnd.h
@@ -103,7 +103,7 @@ class InstallStoppedWnd
 
   CFont default_font_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(InstallStoppedWnd);
+  DISALLOW_COPY_AND_ASSIGN(InstallStoppedWnd);
 };
 
 
@@ -231,7 +231,7 @@ class ProgressWnd
   static const int kMarqueeModeUpdatesMs = 75;
 
   friend class UITest;
-  DISALLOW_EVIL_CONSTRUCTORS(ProgressWnd);
+  DISALLOW_COPY_AND_ASSIGN(ProgressWnd);
 };
 
 }  // namespace omaha

--- a/omaha/ui/ui.h
+++ b/omaha/ui/ui.h
@@ -174,7 +174,7 @@ class OmahaWnd
 
   CustomProgressBarCtrl progress_bar_;
 
-  DISALLOW_EVIL_CONSTRUCTORS(OmahaWnd);
+  DISALLOW_COPY_AND_ASSIGN(OmahaWnd);
 };
 
 // Registers the specified common control classes from the common control DLL.


### PR DESCRIPTION
In third_party/chrome/files/base/basictypes.h the macro `DISALLOW_EVIL_CONSTRUCTORS` maps to the `DISALLOW_COPY_AND_ASSIGN` macro. 

This change removes the macro and replaces usages of `DISALLOW_EVIL_CONSTRUCTORS` with `DISALLOW_COPY_AND_ASSIGN`.