### PR TITLE
Fix for ICE with 16.1.0 toolchain

### DIFF
--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -465,8 +465,9 @@ win_env.AppendUnique(
         '/std:c++17',
         '/W4',
         '/Wall',
-        '/WX',      # warnings as errors
-        '/Zo',      # better debugging support for optimized code
+        '/WX',            # warnings as errors
+        '/Zc:twoPhase-',  # avoids an ICE in service/service_main.h with 16.1.0.
+        '/Zo',            # better debugging support for optimized code
 
         #
         # Disable the following level 4 warnings below.

--- a/omaha/ui/splash_screen.cc
+++ b/omaha/ui/splash_screen.cc
@@ -28,7 +28,6 @@
 #include "omaha/common/lang.h"
 #include "omaha/google_update/resource.h"   // For the IDI_APP
 #include "omaha/goopdate/non_localized_resource.h"
-#include "omaha/ui/scoped_gdi.h"
 #include "omaha/ui/ui.h"
 
 namespace {


### PR DESCRIPTION
An ICE occurs when building with 16.1.0 in service\service_main.h

https://developercommunity.visualstudio.com/content/problem/579068/internal-compiler-error-1610-compiler-file-dagent.html