### PR TITLE
Fix a race in the Scheduler dtor after unique_ptr change

### DIFF
--- a/omaha/core/core.cc
+++ b/omaha/core/core.cc
@@ -287,6 +287,7 @@ HRESULT Core::DoMain(bool is_system, bool is_crash_handler_enabled) {
   });
 
   if (FAILED(hr)) {
+    OPT_LOG(LW, (L"[Failed to start update worker scheduler][0x%08x]", hr));
     return hr;
   }
 
@@ -301,6 +302,11 @@ HRESULT Core::DoMain(bool is_system, bool is_crash_handler_enabled) {
     }
     metric_core_cr_expected_timer_interval_ms = cr_timer_interval;
   }, true /* has_debug_timer */);
+
+  if (FAILED(hr)) {
+    OPT_LOG(LW, (L"[Failed to start code red scheduler][0x%08x]", hr));
+    return hr;
+  }
 
   std::unique_ptr<SystemMonitor> system_monitor(new SystemMonitor(is_system_));
   VERIFY1(SUCCEEDED(system_monitor->Initialize(true)));

--- a/omaha/core/core.h
+++ b/omaha/core/core.h
@@ -30,6 +30,7 @@
 #include "base/basictypes.h"
 #include "omaha/base/shutdown_callback.h"
 #include "omaha/core/google_update_core.h"
+#include "omaha/core/scheduler.h"
 #include "omaha/core/system_monitor.h"
 #include "omaha/goopdate/google_update3.h"
 #include "omaha/third_party/smartany/scoped_any.h"
@@ -114,6 +115,8 @@ class Core
 
   static bool ShouldRunCore(bool is_system);
   static HRESULT UpdateLastCoreRunTime(bool is_system);
+
+  HRESULT InitializeScheduler(const Scheduler* scheduler);
 
   bool is_system_;
 

--- a/omaha/core/scheduler.cc
+++ b/omaha/core/scheduler.cc
@@ -25,7 +25,7 @@ Scheduler::SchedulerItem::SchedulerItem(HANDLE timer_queue,
                                         int start_delay_ms,
                                         int interval_ms,
                                         bool has_debug_timer,
-                                        ScheduledWork work)
+                                        ScheduledWorkWithTimer work)
     : start_delay_ms_(start_delay_ms), interval_ms_(interval_ms), work_(work) {
   if (has_debug_timer) {
     debug_timer_.reset(new HighresTimer());
@@ -124,15 +124,24 @@ Scheduler::~Scheduler() {
   }
 }
 
-HRESULT Scheduler::Start(int interval,
-                         ScheduledWork work,
-                         bool has_debug_timer) const {
-  return Start(interval, interval, work, has_debug_timer);
+HRESULT Scheduler::StartWithDebugTimer(int interval,
+                         ScheduledWorkWithTimer work) const {
+  return DoStart(interval, interval, work, true /*has_debug_timer*/);
 }
 
-HRESULT Scheduler::Start(int start_delay,
+HRESULT Scheduler::StartWithDelay(int delay, int interval,
+                         ScheduledWork work) const {
+
+  return DoStart(delay, interval, std::bind(work), false /* has_debug_timer */);
+}
+
+HRESULT Scheduler::Start(int interval, ScheduledWork work) const {
+  return DoStart(interval, interval, std::bind(work), false /*has_debug_timer*/);
+}
+
+HRESULT Scheduler::DoStart(int start_delay,
                          int interval,
-                         ScheduledWork work_fn,
+                         ScheduledWorkWithTimer work_fn,
                          bool has_debug_timer) const {
   CORE_LOG(L1, (L"[Scheduler::Start]"));
 

--- a/omaha/core/scheduler.cc
+++ b/omaha/core/scheduler.cc
@@ -14,7 +14,7 @@
 // ========================================================================
 
 #include "omaha/core/scheduler.h"
-#include <algorithm>
+
 #include "omaha/base/debug.h"
 #include "omaha/base/error.h"
 #include "omaha/base/highres_timer-win32.h"
@@ -26,104 +26,119 @@
 
 namespace omaha {
 
-Scheduler::Scheduler(const Core& core)
-    : core_(core) {
-  CORE_LOG(L1, (_T("[Scheduler::Scheduler]")));
+SchedulerItem::SchedulerItem(HANDLE timer_queue,
+                             int start_delay_ms,
+                             int interval_ms,
+                             bool has_debug_timer,
+                             ScheduledWork work_fn)
+    : start_delay_ms(start_delay_ms), interval_ms(interval_ms), work(work_fn) {
+  if (has_debug_timer) {
+    debug_timer.reset(new HighresTimer());
+  }
+
+  if (timer_queue) {
+    timer.reset(
+        new QueueTimer(timer_queue, &SchedulerItem::TimerCallback, this));
+    VERIFY1(SUCCEEDED(
+        ScheduleNext(timer.get(), debug_timer.get(), start_delay_ms)));
+  }
+}
+
+SchedulerItem::~SchedulerItem() {
+  // QueueTimer dtor may block for pending callbacks
+  timer.reset(nullptr);
+}
+
+// static
+HRESULT SchedulerItem::ScheduleNext(QueueTimer* timer,
+                                    HighresTimer* debug_timer,
+                                    int start_after_ms) {
+  if (!timer) {
+    return E_FAIL;
+  }
+
+  if (debug_timer) {
+    debug_timer->Start();
+  }
+
+  const HRESULT hr = timer->Start(start_after_ms, 0, WT_EXECUTEONLYONCE);
+
+  if (FAILED(hr)) {
+    CORE_LOG(LE, (L"[can't start queue timer][0x%08x]", hr));
+  }
+
+  return hr;
+}
+
+// static
+void SchedulerItem::TimerCallback(QueueTimer* timer) {
+  ASSERT1(timer);
+  if (!timer) {
+    return;
+  }
+
+  SchedulerItem* item = reinterpret_cast<SchedulerItem*>(timer->ctx());
+  ASSERT1(item);
+
+  if (!item) {
+    return;
+  }
+
+  // This may be long running, item may be deleted in the meantime
+  if (item && item->work) {
+    item->work(item->debug_timer.get());
+  }
+
+  if (item) {
+    const HRESULT hr = SchedulerItem::ScheduleNext(
+        timer, item->debug_timer.get(), item->interval_ms);
+    if (FAILED(hr)) {
+      CORE_LOG(L1, (L"[Scheduling next timer callback failed][0x%08x]", hr));
+    }
+  }
+}
+
+Scheduler::Scheduler() {
+  CORE_LOG(L1, (L"[Scheduler::Scheduler]"));
+  timer_queue_ = ::CreateTimerQueue();
+  if (!timer_queue_) {
+    CORE_LOG(LE, (L"[Failed to create Timer Queue][%d]", ::GetLastError()));
+  }
 }
 
 Scheduler::~Scheduler() {
-  CORE_LOG(L1, (_T("[Scheduler::~Scheduler]")));
+  CORE_LOG(L1, (L"[Scheduler::~Scheduler]"));
 
-  if (update_timer_.get()) {
-    update_timer_.reset(NULL);
-  }
-
-  if (code_red_timer_.get()) {
-    code_red_timer_.reset(NULL);
-  }
+  // Reset all the timers
+  timers_.clear();
 
   if (timer_queue_) {
     // The destructor blocks on deleting the timer queue and it waits for
     // all timer callbacks to complete.
     ::DeleteTimerQueueEx(timer_queue_, INVALID_HANDLE_VALUE);
+    timer_queue_ = nullptr;
   }
 }
 
-HRESULT Scheduler::Initialize() {
-  CORE_LOG(L1, (_T("[Scheduler::Initialize]")));
+HRESULT Scheduler::Start(int interval,
+                         ScheduledWork work,
+                         bool has_debug_timer) {
+  return Start(interval, interval, work, has_debug_timer);
+}
 
-  timer_queue_ = ::CreateTimerQueue();
+HRESULT Scheduler::Start(int start_delay,
+                         int interval,
+                         ScheduledWork work_fn,
+                         bool has_debug_timer) {
+  CORE_LOG(L1, (L"[Scheduler::Start]"));
+
   if (!timer_queue_) {
     return HRESULTFromLastError();
   }
 
-  cr_debug_timer_.reset(new HighresTimer);
-
-  update_timer_.reset(new QueueTimer(timer_queue_,
-                                     &Scheduler::TimerCallback,
-                                     this));
-  code_red_timer_.reset(new QueueTimer(timer_queue_,
-                                       &Scheduler::TimerCallback,
-                                       this));
-
-  ConfigManager* config_manager = ConfigManager::Instance();
-  int cr_timer_interval_ms = config_manager->GetCodeRedTimerIntervalMs();
-  VERIFY1(SUCCEEDED(ScheduleCodeRedTimer(cr_timer_interval_ms)));
-
-  int au_timer_interval_ms = config_manager->GetUpdateWorkerStartUpDelayMs();
-  VERIFY1(SUCCEEDED(ScheduleUpdateTimer(au_timer_interval_ms)));
-
+  timers_.emplace_back(timer_queue_, start_delay, interval, has_debug_timer,
+                       work_fn);
   return S_OK;
 }
 
-void Scheduler::TimerCallback(QueueTimer* timer) {
-  ASSERT1(timer);
-  Scheduler* scheduler = static_cast<Scheduler*>(timer->ctx());
-  ASSERT1(scheduler);
-  scheduler->HandleCallback(timer);
-}
-
-// First, do the useful work and then reschedule the timer. Otherwise, it is
-// possible that timer notifications overlap, and the timer can't be further
-// rescheduled: http://b/1228095
-void Scheduler::HandleCallback(QueueTimer* timer) {
-  ConfigManager* config_manager = ConfigManager::Instance();
-  if (update_timer_.get() == timer) {
-    core_.StartUpdateWorker();
-    int au_timer_interval_ms = config_manager->GetAutoUpdateTimerIntervalMs();
-    VERIFY1(SUCCEEDED(ScheduleUpdateTimer(au_timer_interval_ms)));
-  } else if (code_red_timer_.get() == timer) {
-    core_.StartCodeRed();
-    int actual_time_ms = static_cast<int>(cr_debug_timer_->GetElapsedMs());
-    metric_core_cr_actual_timer_interval_ms = actual_time_ms;
-    CORE_LOG(L3, (_T("[code red actual period][%d ms]"), actual_time_ms));
-    int cr_timer_interval_ms = config_manager->GetCodeRedTimerIntervalMs();
-    VERIFY1(SUCCEEDED(ScheduleCodeRedTimer(cr_timer_interval_ms)));
-  } else {
-    ASSERT1(false);
-  }
-
-  // Since core is a long lived process, aggregate its metrics once in a while.
-  core_.AggregateMetrics();
-}
-
-HRESULT Scheduler::ScheduleUpdateTimer(int interval_ms) {
-  HRESULT hr = update_timer_->Start(interval_ms, 0, WT_EXECUTEONLYONCE);
-  if (FAILED(hr)) {
-    CORE_LOG(LE, (_T("[can't start update queue timer][0x%08x]"), hr));
-  }
-  return hr;
-}
-
-HRESULT Scheduler::ScheduleCodeRedTimer(int interval_ms) {
-  metric_core_cr_expected_timer_interval_ms = interval_ms;
-  cr_debug_timer_->Start();
-  HRESULT hr = code_red_timer_->Start(interval_ms, 0, WT_EXECUTEONLYONCE);
-  if (FAILED(hr)) {
-    CORE_LOG(LE, (_T("[can't start Code Red queue timer][0x%08x]"), hr));
-  }
-  return hr;
-}
-
 }  // namespace omaha
-

--- a/omaha/core/scheduler.cc
+++ b/omaha/core/scheduler.cc
@@ -40,7 +40,7 @@ Scheduler::SchedulerItem::SchedulerItem(HANDLE timer_queue,
 }
 
 Scheduler::SchedulerItem::~SchedulerItem() {
-  // QueueTimer dtor may block for pending callbacks
+  // QueueTimer dtor may block for pending callbacks.
   if (timer_) {
     timer_.reset();
   }
@@ -88,7 +88,7 @@ void Scheduler::SchedulerItem::TimerCallback(QueueTimer* timer) {
 
   // This may be long running, |item| may be deleted in the meantime,
   // however the dtor should block on deleting the |timer| and allow
-  // pending callbacks to run
+  // pending callbacks to run.
   if (item && item->work_) {
     item->work_(item->debug_timer());
   }
@@ -114,7 +114,6 @@ Scheduler::Scheduler() {
 Scheduler::~Scheduler() {
   CORE_LOG(L1, (L"[Scheduler::~Scheduler]"));
 
-  // Reset all the timers
   timers_.clear();
 
   if (timer_queue_) {

--- a/omaha/core/scheduler.cc
+++ b/omaha/core/scheduler.cc
@@ -94,8 +94,9 @@ void Scheduler::SchedulerItem::TimerCallback(QueueTimer* timer) {
   }
 
   if (item) {
-    const HRESULT hr = SchedulerItem::ScheduleNext(
-        timer, item->debug_timer(), item->interval_ms());
+    const HRESULT hr = SchedulerItem::ScheduleNext(timer,
+                                                   item->debug_timer(),
+                                                   item->interval_ms());
     if (FAILED(hr)) {
       CORE_LOG(L1, (L"[Scheduling next timer callback failed][0x%08x]", hr));
     }
@@ -125,24 +126,24 @@ Scheduler::~Scheduler() {
 }
 
 HRESULT Scheduler::StartWithDebugTimer(int interval,
-                         ScheduledWorkWithTimer work) const {
+                                       ScheduledWorkWithTimer work) const {
   return DoStart(interval, interval, work, true /*has_debug_timer*/);
 }
 
-HRESULT Scheduler::StartWithDelay(int delay, int interval,
-                         ScheduledWork work) const {
-
-  return DoStart(delay, interval, std::bind(work), false /* has_debug_timer */);
+HRESULT Scheduler::StartWithDelay(int delay,
+                                  int interval,
+                                  ScheduledWork work) const {
+  return DoStart(delay, interval, std::bind(work));
 }
 
 HRESULT Scheduler::Start(int interval, ScheduledWork work) const {
-  return DoStart(interval, interval, std::bind(work), false /*has_debug_timer*/);
+  return DoStart(interval, interval, std::bind(work));
 }
 
 HRESULT Scheduler::DoStart(int start_delay,
-                         int interval,
-                         ScheduledWorkWithTimer work_fn,
-                         bool has_debug_timer) const {
+                           int interval,
+                           ScheduledWorkWithTimer work_fn,
+                           bool has_debug_timer) const {
   CORE_LOG(L1, (L"[Scheduler::Start]"));
 
   if (!timer_queue_) {

--- a/omaha/core/scheduler.h
+++ b/omaha/core/scheduler.h
@@ -38,11 +38,11 @@ class Scheduler {
   explicit Scheduler();
   ~Scheduler();
 
-  // Starts the scheduler that executes |work| with regular |interval| (ms)
+  // Starts the scheduler that executes |work| with regular |interval| (ms).
   HRESULT Start(int interval, ScheduledWork work) const;
 
-  // Starts the scheduler that executes |work| with regular |interval| (ms) after
-  // an initial |delay| (ms)
+  // Starts the scheduler that executes |work| with regular |interval| (ms)
+  // after an initial |delay| (ms).
   HRESULT StartWithDelay(int delay, int interval, ScheduledWork work) const;
 
   // Start the scheduler on a regular |interval| (ms). The callback is provided
@@ -92,7 +92,7 @@ class Scheduler {
                   ScheduledWorkWithTimer work,
                   bool has_debug_timer = false) const;
 
-  // Timer queue handle for all QueueTimer objects
+  // Timer queue handle for all QueueTimer objects.
   HANDLE timer_queue_;
 
   mutable std::list<SchedulerItem> timers_;

--- a/omaha/core/scheduler.h
+++ b/omaha/core/scheduler.h
@@ -50,7 +50,6 @@ class Scheduler {
   HRESULT StartWithDebugTimer(int interval, ScheduledWorkWithTimer work) const;
 
  private:
-  // Represents a unit of work that scheduler executes.
   class SchedulerItem {
    public:
     SchedulerItem(HANDLE timer_queue,
@@ -68,21 +67,16 @@ class Scheduler {
     int interval_ms() const { return interval_ms_; }
 
    private:
-    // Initial delay for the |timer_|
     int start_delay_ms_;
-
-    // Interval in milliseconds after which |timer_| callback should be called
     int interval_ms_;
 
-    // Timer used for scheduling
     std::unique_ptr<QueueTimer> timer_;
 
     // Measures the actual time interval between events for debugging
-    // purposes. The timer is started when a red alarm is set and then,
+    // purposes. The timer is started when an alarm is set and then,
     // the value of the timer is read when the alarm goes off.
     std::unique_ptr<HighresTimer> debug_timer_;
 
-    // Work function to be run on the timer
     ScheduledWorkWithTimer work_;
 
     static HRESULT ScheduleNext(QueueTimer* timer,
@@ -93,15 +87,12 @@ class Scheduler {
     DISALLOW_COPY_AND_ASSIGN(SchedulerItem);
   };
 
-  // Starts the scheduler that executes |work| when |interval| (ms) elapses,
-  // after an initial delay of |start_delay| (ms).
-  // Default debug timer to false.
   HRESULT DoStart(int start_delay,
                   int interval,
                   ScheduledWorkWithTimer work,
                   bool has_debug_timer = false) const;
 
-  // Timer queue handle for all timers
+  // Timer queue handle for all QueueTimer objects
   HANDLE timer_queue_;
 
   mutable std::list<SchedulerItem> timers_;

--- a/omaha/core/scheduler.h
+++ b/omaha/core/scheduler.h
@@ -61,7 +61,7 @@ class Scheduler {
     ~SchedulerItem();
 
     HighresTimer* GetDebugTimer() {
-      return debug_timer_ ? nullptr : debug_timer_.get();
+      return debug_timer_ ? debug_timer_.get() : nullptr;
     }
 
     int GetIntervalMs() const { return interval_ms_; }

--- a/omaha/core/scheduler.h
+++ b/omaha/core/scheduler.h
@@ -19,70 +19,85 @@
 #ifndef OMAHA_CORE_SCHEDULER_H__
 #define OMAHA_CORE_SCHEDULER_H__
 
-#include <atlstr.h>
 #include <windows.h>
 #include <functional>
 #include <list>
 #include <memory>
 
 #include "base/basictypes.h"
+#include "omaha/base/highres_timer-win32.h"
+#include "omaha/base/queue_timer.h"
 
 namespace omaha {
 
-class Core;
-class HighresTimer;
-class QueueTimer;
-
 using ScheduledWork = std::function<void(HighresTimer*)>;
-
-struct SchedulerItem {
-  SchedulerItem(HANDLE timer_queue,
-                int start_delay,
-                int interval,
-                bool has_debug_timer,
-                ScheduledWork work_fn);
-
-  ~SchedulerItem();
-
-  int start_delay_ms;
-  int interval_ms;
-  std::unique_ptr<QueueTimer> timer;
-
-  // Measures the actual time interval between events for debugging
-  // purposes. The timer is started when a red alarm is set and then,
-  // the value of the timer is read when the alarm goes off.
-  std::unique_ptr<HighresTimer> debug_timer;
-
-  // Work function to be run on the timer
-  ScheduledWork work;
-
-  static HRESULT ScheduleNext(QueueTimer* timer,
-                              HighresTimer* debug_timer,
-                              int interval_ms);
-  static void TimerCallback(QueueTimer* timer);
-
-  DISALLOW_COPY_AND_ASSIGN(SchedulerItem);
-};
 
 class Scheduler {
  public:
   explicit Scheduler();
   ~Scheduler();
 
-  // Starts the scheduler with a delay.
-  // Default debug timer to false
+  // Starts the scheduler that executes |work| when |interval| (ms) elapses,
+  // after an initial delay of |start_delay| (ms).
+  // Default debug timer to false.
   HRESULT Start(int start_delay,
                 int interval,
                 ScheduledWork work,
                 bool has_debug_timer = false);
 
-  // Starts the scheduler with regular interval
+  // Starts the scheduler that executes |work| with regular |interval| (ms)
   HRESULT Start(int interval, ScheduledWork work, bool has_debug_timer = false);
 
  private:
+  // Represents a unit of work that scheduler executes.
+  class SchedulerItem {
+  public:
+    SchedulerItem(HANDLE timer_queue,
+                  int start_delay,
+                  int interval,
+                  bool has_debug_timer,
+                  ScheduledWork work_fn);
+
+    ~SchedulerItem();
+
+    HighresTimer* GetDebugTimer() {
+      return debug_timer_ ? nullptr : debug_timer_.get();
+    }
+
+    int GetIntervalMs() const { return interval_ms_; }
+  private:
+
+    // Initial delay for the |timer_|
+    int start_delay_ms_;
+
+    // Interval in milliseconds after which |timer_| callback should be called
+    int interval_ms_;
+
+    // Timer used for scheduling
+    std::unique_ptr<QueueTimer> timer_;
+
+    // Measures the actual time interval between events for debugging
+    // purposes. The timer is started when a red alarm is set and then,
+    // the value of the timer is read when the alarm goes off.
+    std::unique_ptr<HighresTimer> debug_timer_;
+
+    // Work function to be run on the timer
+    ScheduledWork work_;
+
+    static HRESULT ScheduleNext(QueueTimer* timer,
+                                HighresTimer* debug_timer,
+                                int interval_ms);
+    static void TimerCallback(QueueTimer* timer);
+
+    DISALLOW_COPY_AND_ASSIGN(SchedulerItem);
+  };
+
   // Timer queue handle for all timers
   HANDLE timer_queue_;
+
+  // Use list to avoid copying SchedulerItems
   std::list<SchedulerItem> timers_;
+
   DISALLOW_COPY_AND_ASSIGN(Scheduler);
 };
 

--- a/omaha/core/scheduler.h
+++ b/omaha/core/scheduler.h
@@ -43,10 +43,11 @@ class Scheduler {
   HRESULT Start(int start_delay,
                 int interval,
                 ScheduledWork work,
-                bool has_debug_timer = false);
+                bool has_debug_timer = false) const;
 
   // Starts the scheduler that executes |work| with regular |interval| (ms)
-  HRESULT Start(int interval, ScheduledWork work, bool has_debug_timer = false);
+  HRESULT Start(int interval, ScheduledWork work,
+                bool has_debug_timer = false) const;
 
  private:
   // Represents a unit of work that scheduler executes.
@@ -60,11 +61,11 @@ class Scheduler {
 
     ~SchedulerItem();
 
-    HighresTimer* GetDebugTimer() {
+    HighresTimer* debug_timer() const {
       return debug_timer_ ? debug_timer_.get() : nullptr;
     }
 
-    int GetIntervalMs() const { return interval_ms_; }
+    int interval_ms() const { return interval_ms_; }
   private:
 
     // Initial delay for the |timer_|
@@ -95,8 +96,7 @@ class Scheduler {
   // Timer queue handle for all timers
   HANDLE timer_queue_;
 
-  // Use list to avoid copying SchedulerItems
-  std::list<SchedulerItem> timers_;
+  mutable std::list<SchedulerItem> timers_;
 
   DISALLOW_COPY_AND_ASSIGN(Scheduler);
 };

--- a/omaha/core/scheduler_unittest.cc
+++ b/omaha/core/scheduler_unittest.cc
@@ -15,6 +15,8 @@
 
 #include "omaha/core/scheduler.h"
 
+#include <functional>
+
 #include "omaha/base/constants.h"
 #include "omaha/base/highres_timer-win32.h"
 #include "omaha/testing/unit_test.h"
@@ -28,13 +30,17 @@ inline void ASSERT_SIGNALLED_BEFORE(HANDLE handle, DWORD timeout_ms) {
   ASSERT_EQ(WAIT_OBJECT_0, ::WaitForSingleObject(handle, timeout_ms));
 }
 
-inline void ASSERT_ALL_SIGNALLED_BEFORE(int count,
-                                        HANDLE* handles,
+inline void ASSERT_ALL_SIGNALLED_BEFORE(std::vector<scoped_handle>& handles,
                                         DWORD timeout_ms) {
   // Wait for all handles
   constexpr bool kWaitAll = true;
-  ASSERT_EQ(WAIT_OBJECT_0,
-            ::WaitForMultipleObjects(count, handles, kWaitAll, timeout_ms));
+  std::vector<HANDLE> raw_handles;
+  for (auto& handle : handles) {
+    raw_handles.emplace_back(get(handle));
+  }
+  const DWORD res = ::WaitForMultipleObjects(
+      raw_handles.size(), &raw_handles[0], kWaitAll, timeout_ms);
+  ASSERT_EQ(WAIT_OBJECT_0, res);
 }
 
 inline void ASSERT_TIMEOUT_AFTER(HANDLE handle, DWORD timeout_ms) {
@@ -51,30 +57,30 @@ class SchedulerTest : public ::testing::Test {
 
 TEST_F(SchedulerTest, ScheduledTaskReschedules) {
   int call_count = 0;
-  std::vector<HANDLE> event_handles(4);
+  std::vector<scoped_handle> event_handles(4);
 
   for (auto& handle : event_handles) {
-    handle = ::CreateEvent(NULL, true, false, NULL);
+    reset(handle, ::CreateEvent(NULL, true, false, NULL));
   }
 
   Scheduler scheduler;
   // Increase call count after 200ms and every 300ms afterwards
   HRESULT hr = scheduler.Start(200, 300, [&call_count, &event_handles](auto*) {
     if (call_count < 4) {
-      ::SetEvent(event_handles[call_count]);
+      ::SetEvent(get(event_handles[call_count]));
     }
     call_count++;
   });
   ASSERT_SUCCEEDED(hr);
-  ASSERT_ALL_SIGNALLED_BEFORE(4, &event_handles[0], 1500);
+  ASSERT_ALL_SIGNALLED_BEFORE(event_handles, 1500);
   EXPECT_EQ(4, call_count);
 }
 
 TEST_F(SchedulerTest, DeleteWhenCallbackExpires) {
   int call_count = 0;
-  std::vector<HANDLE> callbacks(2);
+  std::vector<scoped_handle> callbacks(2);
   for (auto& handle : callbacks) {
-    handle = ::CreateEvent(NULL, true, false, NULL);
+    reset(handle, ::CreateEvent(NULL, true, false, NULL));
   }
 
   // Create the scheduler in a new scope
@@ -82,14 +88,14 @@ TEST_F(SchedulerTest, DeleteWhenCallbackExpires) {
     Scheduler scheduler;
     // Timer that runs every 250 ms
     HRESULT hr = scheduler.Start(250, [&call_count, &callbacks](auto*) {
-      ::SetEvent(callbacks[call_count]);
+      ::SetEvent(get(callbacks[call_count]));
       call_count++;
     });
     // Wait for one callback, then scheduler should go out of scope
-    ASSERT_SIGNALLED_BEFORE(callbacks[0], 300);
+    ASSERT_SIGNALLED_BEFORE(get(callbacks[0]), 300);
   }
   // Second callback should never fire
-  ASSERT_TIMEOUT_AFTER(callbacks[1], 1000);
+  ASSERT_TIMEOUT_AFTER(get(callbacks[1]), 1000);
   EXPECT_EQ(call_count, 1);
 }
 
@@ -97,17 +103,17 @@ TEST_F(SchedulerTest, DeleteSoonBeforeCallbackExpires) {
   int call_count = 0;
   constexpr int kInterval = 500;
   constexpr int kTimeout = kInterval - 10;
-  HANDLE callback_fired = ::CreateEvent(NULL, true, false, NULL);
+  scoped_handle callback_fired(::CreateEvent(NULL, true, false, NULL));
   {
     Scheduler scheduler;
     // Task runs every 500ms
     HRESULT hr =
-        scheduler.Start(kInterval, [&call_count, callback_fired](auto*) {
+        scheduler.Start(kInterval, [&call_count, &callback_fired](auto*) {
           call_count++;
-          ::SetEvent(callback_fired);
+          ::SetEvent(get(callback_fired));
         });
     ASSERT_SUCCEEDED(hr);
-    ASSERT_TIMEOUT_AFTER(callback_fired, kTimeout);
+    ASSERT_TIMEOUT_AFTER(get(callback_fired), kTimeout);
   }
   EXPECT_EQ(call_count, 0);
 }
@@ -116,18 +122,18 @@ TEST_F(SchedulerTest, DoesntUseDebugTimer) {
   int call_count = 0;
   constexpr int kExpectedIntervalMs = 100;
   constexpr int kTimeout = 500;
-  HANDLE callback_fired = ::CreateEvent(NULL, true, false, NULL);
+  scoped_handle callback_fired(::CreateEvent(NULL, true, false, NULL));
   {
     Scheduler scheduler;
     // Task runs every 100ms
     HRESULT hr = scheduler.Start(
-        kExpectedIntervalMs, [&call_count, callback_fired](auto* debug_timer) {
+        kExpectedIntervalMs, [&call_count, &callback_fired](auto* debug_timer) {
           ASSERT_EQ(nullptr, debug_timer);
           call_count++;
-          ::SetEvent(callback_fired);
+          ::SetEvent(get(callback_fired));
         });
     ASSERT_SUCCEEDED(hr);
-    ASSERT_SIGNALLED_BEFORE(callback_fired, kTimeout);
+    ASSERT_SIGNALLED_BEFORE(get(callback_fired), kTimeout);
   }
   ASSERT_EQ(call_count, 1);
 }
@@ -135,45 +141,46 @@ TEST_F(SchedulerTest, DoesntUseDebugTimer) {
 TEST_F(SchedulerTest, UsesDebugTimer) {
   int call_count = 0;
   constexpr int kExpectedIntervalMs = 500;
-  HANDLE callback_handle = ::CreateEvent(NULL, true, false, NULL);
+  scoped_handle callback_handle(::CreateEvent(NULL, true, false, NULL));
   {
     Scheduler scheduler;
     // Task runs every 500ms
     HRESULT hr = scheduler.Start(
         kExpectedIntervalMs,
-        [&call_count, kExpectedIntervalMs, callback_handle](auto* debug_timer) {
+        [&call_count, kExpectedIntervalMs, &callback_handle](auto* debug_timer) {
           ASSERT_TRUE(debug_timer != nullptr);
           EXPECT_GE(debug_timer->GetElapsedMs(), kExpectedIntervalMs);
           call_count++;
-          ::SetEvent(callback_handle);
+          ::SetEvent(get(callback_handle));
         },
         true /* has_debug_timer */);
     ASSERT_SUCCEEDED(hr);
-    ASSERT_SIGNALLED_BEFORE(callback_handle, kExpectedIntervalMs + 100);
+    ASSERT_SIGNALLED_BEFORE(get(callback_handle), kExpectedIntervalMs + 100);
   }
   ASSERT_EQ(call_count, 1);
 }
 
 TEST_F(SchedulerTest, LongCallbackBlocks) {
   auto scheduler = std::make_unique<Scheduler>();
+  constexpr int kInterval = 50;
   constexpr int kCallbackDelay = 500;
   HighresTimer timer;
-  HANDLE callback_start = ::CreateEvent(NULL, true, false, NULL);
-  HANDLE callback_end = ::CreateEvent(NULL, true, false, NULL);
+  scoped_handle callback_start(::CreateEvent(NULL, true, false, NULL));
+  scoped_handle callback_end(::CreateEvent(NULL, true, false, NULL));
 
   // Run after 50ms, callback will take 500ms to execute
   HRESULT hr = scheduler->Start(
-      50, [kCallbackDelay, callback_start, callback_end](auto*) {
-        ::SetEvent(callback_start);
+      kInterval, [kCallbackDelay, &callback_start, &callback_end](auto*) {
+        ::SetEvent(get(callback_start));
         Sleep(kCallbackDelay);
-        ::SetEvent(callback_end);
+        ::SetEvent(get(callback_end));
       });
   ASSERT_SUCCEEDED(hr);
   // Try deleting, record how much time it takes
-  ASSERT_SIGNALLED_BEFORE(callback_start, 100);
+  ASSERT_SIGNALLED_BEFORE(get(callback_start), 100);
   timer.Start();
   scheduler.reset();
-  ASSERT_SIGNALLED_BEFORE(callback_end, 600);
+  ASSERT_SIGNALLED_BEFORE(get(callback_end), 600);
   EXPECT_GE(timer.GetElapsedMs(), kCallbackDelay);
 }
 

--- a/omaha/core/scheduler_unittest.cc
+++ b/omaha/core/scheduler_unittest.cc
@@ -1,0 +1,155 @@
+// Copyright 2007-2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========================================================================
+
+#include "omaha/core/scheduler.h"
+
+#include "omaha/base/constants.h"
+#include "omaha/base/highres_timer-win32.h"
+#include "omaha/testing/unit_test.h"
+#include "omaha/third_party/smartany/scoped_any.h"
+
+namespace omaha {
+
+class SchedulerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(SchedulerTest, ScheduledTaskReschedules) {
+  int call_count = 0;
+
+  {
+    std::vector<HANDLE> event_handles(4);
+    for (auto& handle : event_handles) {
+      handle = ::CreateEvent(NULL, true, false, NULL);
+    }
+
+    Scheduler scheduler;
+    // Increase call count after 200ms and every 300ms afterwards
+    HRESULT hr =
+        scheduler.Start(200, 300, [&call_count, &event_handles](auto*) {
+          if (call_count < 4) {
+            ::SetEvent(event_handles[call_count]);
+          }
+          call_count++;
+        });
+
+    ASSERT_EQ(WAIT_OBJECT_0,
+              ::WaitForMultipleObjects(4, &event_handles[0], true, 1500));
+  }
+  // One after 200ms, then 2x 1000ms
+}
+
+TEST_F(SchedulerTest, DeleteWhenCallbackExpires) {
+  int call_count = 0;
+  std::vector<HANDLE> callbacks(2);
+  for (auto& handle : callbacks) {
+    handle = ::CreateEvent(NULL, true, false, NULL);
+  }
+
+  {
+    Scheduler scheduler;
+    // Timer that runs every 250 ms
+    HRESULT hr = scheduler.Start(250, [&call_count, &callbacks](auto*) {
+      ::SetEvent(callbacks[call_count]);
+      call_count++;
+    });
+    // Wait for one callback, then scheduler should go out of scope
+    ASSERT_EQ(WAIT_OBJECT_0, ::WaitForSingleObject(callbacks[0], 300));
+  }
+  // Second callback should never fire
+  ASSERT_EQ(WAIT_TIMEOUT, ::WaitForSingleObject(callbacks[1], 1000));
+  EXPECT_EQ(call_count, 1);
+}
+
+TEST_F(SchedulerTest, DeleteSoonBeforeCallbackExpires) {
+  int call_count = 0;
+  HANDLE callback_fired = ::CreateEvent(NULL, true, false, NULL);
+  {
+    Scheduler scheduler;
+    // Task runs every 500ms
+    HRESULT hr = scheduler.Start(500, [&call_count, callback_fired](auto*) {
+      call_count++;
+      ::SetEvent(callback_fired);
+    });
+    ASSERT_EQ(WAIT_TIMEOUT, ::WaitForSingleObject(callback_fired, 490));
+  }
+  EXPECT_EQ(call_count, 0);
+}
+
+TEST_F(SchedulerTest, DoesntUseDebugTimer) {
+  int call_count = 0;
+  const int kExpectedIntervalMs = 100;
+  HANDLE callback_fired = ::CreateEvent(NULL, true, false, NULL);
+  {
+    Scheduler scheduler;
+    // Task runs every 100ms
+    HRESULT hr = scheduler.Start(
+        kExpectedIntervalMs, [&call_count, callback_fired](auto* debug_timer) {
+          ASSERT_EQ(nullptr, debug_timer);
+          call_count++;
+          ::SetEvent(callback_fired);
+        });
+    ASSERT_EQ(WAIT_OBJECT_0, ::WaitForSingleObject(callback_fired, 500));
+  }
+  ASSERT_EQ(call_count, 1);
+}
+
+TEST_F(SchedulerTest, UsesDebugTimer) {
+  int call_count = 0;
+  constexpr int kExpectedIntervalMs = 500;
+  HANDLE signaled = ::CreateEvent(NULL, true, false, NULL);
+  {
+    Scheduler scheduler;
+    // Task runs every 500ms
+    HRESULT hr = scheduler.Start(
+        kExpectedIntervalMs,
+        [&call_count, kExpectedIntervalMs, signaled](auto* debug_timer) {
+          EXPECT_GE(debug_timer->GetElapsedMs(), kExpectedIntervalMs);
+          call_count++;
+          ::SetEvent(signaled);
+        },
+        true);
+    ASSERT_EQ(WAIT_OBJECT_0,
+              ::WaitForSingleObject(signaled, kExpectedIntervalMs + 100));
+  }
+  ASSERT_EQ(call_count, 1);
+}
+
+TEST_F(SchedulerTest, LongCallbackBlocks) {
+  auto scheduler = std::make_unique<Scheduler>();
+  constexpr int kCallbackDelay = 500;
+  HighresTimer timer;
+  HANDLE callback_start = ::CreateEvent(NULL, true, false, NULL);
+  HANDLE callback_end = ::CreateEvent(NULL, true, false, NULL);
+
+  // Run after 50ms, callback will take 500ms to execute
+  HRESULT hr = scheduler->Start(
+      50, [kCallbackDelay, callback_start, callback_end](auto*) {
+        ::SetEvent(callback_start);
+        Sleep(kCallbackDelay);
+        ::SetEvent(callback_end);
+      });
+
+  // Try deleting, record how much time it takes
+  ASSERT_EQ(WAIT_OBJECT_0, ::WaitForSingleObject(callback_start, 100));
+  timer.Start();
+  scheduler.reset();
+  ASSERT_EQ(WAIT_OBJECT_0, ::WaitForSingleObject(callback_end, 600));
+  EXPECT_GE(timer.GetElapsedMs(), kCallbackDelay);
+}
+
+}  // namespace omaha

--- a/omaha/testing/build.scons
+++ b/omaha/testing/build.scons
@@ -457,6 +457,7 @@ omaha_unittest_inputs = [
 
     # Core unit tests
     '../core/core_unittest.cc',
+    '../core/scheduler_unittest.cc',
     '../core/system_monitor_unittest.cc',
     '../core/google_update_core_unittest.cc',
 


### PR DESCRIPTION
The issue is related to #177. The `scoped_ptr::reset method` would first destroy an object and
then set the contained ptr to null. The `std::unique_ptr`, however, does it in the reverse order.
The destructor of `QueueTimer` waits on a critical section that allows it
to wait for pending timer callbacks during teardown.
Therefore, the `Scheduler::~Scheduler` will wait on `update_timer.reset(...)`
in one thread, while trying to access `update_timer` value in another thread.

With this change, the pointer passed as the context of the timer callback will
be use instead of trying to access the contained `unique_ptr` value.