### PR TITLE
Fix leak of the region GDI handle

### DIFF
--- a/omaha/ui/owner_draw_title_bar.cc
+++ b/omaha/ui/owner_draw_title_bar.cc
@@ -650,7 +650,7 @@ LRESULT CustomProgressBarCtrl::OnPaint(UINT,
     ASSERT1(progress_bar_rect.left <= progress_bar_rect.right);
   }
 
-  CRgnHandle rgn(::CreateRectRgnIndirect(&client_rect));
+  CRgn rgn(::CreateRectRgnIndirect(&client_rect));
   CRgn rgn_temp(::CreateRectRgnIndirect(&progress_bar_rect));
   VERIFY1(rgn.CombineRgn(rgn_temp, RGN_DIFF) != RGN_ERROR);
 


### PR DESCRIPTION
`CRgnHandle rgn` leaks the region created by the `CreateRectRgnIndirect` method in each OnPaint method call.

This means, that if the download takes a while and we exhaust the GDI object limit, then `CreateRectRgnIndirect` will fail and bootstrapper would crash.

I'd guess it's a bad copy-paste from other places where `CreateRectRgnIndirect`.
Changing `rgn` to be of type `CRgn` ensures that `DeleteObject` is called when the object goes out of scope.