### PR TITLE
Reduce the size on disk of GoogleUpdateCore.exe

### DIFF
--- a/omaha/common/config_manager.cc
+++ b/omaha/common/config_manager.cc
@@ -971,36 +971,6 @@ int ConfigManager::GetAutoUpdateJitterMs() const {
   return (random_delay % kMaxJitterMs);
 }
 
-time64 ConfigManager::GetTimeSinceLastCoreRunMs(bool is_machine) const {
-  const time64 now = GetCurrentMsTime();
-  const time64 last_core_run = GetLastCoreRunTimeMs(is_machine);
-
-  if (now < last_core_run) {
-    return ULONG64_MAX;
-  }
-
-  return now - last_core_run;
-}
-
-time64 ConfigManager::GetLastCoreRunTimeMs(bool is_machine) const {
-  const TCHAR* reg_update_key(is_machine ? MACHINE_REG_UPDATE :
-                                           USER_REG_UPDATE);
-  time64 last_core_run_time = 0;
-  if (SUCCEEDED(RegKey::GetValue(reg_update_key,
-                                 kRegValueLastCoreRun,
-                                 &last_core_run_time))) {
-    return last_core_run_time;
-  }
-
-  return 0;
-}
-
-HRESULT ConfigManager::SetLastCoreRunTimeMs(bool is_machine, time64 time) {
-  const TCHAR* reg_update_key(is_machine ? MACHINE_REG_UPDATE :
-                                           USER_REG_UPDATE);
-  return RegKey::SetValue(reg_update_key, kRegValueLastCoreRun, time);
-}
-
 // Overrides CodeRedCheckPeriodMs. Implements a lower bound value. Returns
 // INT_MAX if the registry value exceeds INT_MAX.
 int ConfigManager::GetCodeRedTimerIntervalMs() const {

--- a/omaha/common/config_manager.h
+++ b/omaha/common/config_manager.h
@@ -325,11 +325,6 @@ class ConfigManager {
   // by UpdateDev settings.
   int GetAutoUpdateJitterMs() const;
 
-  // Core interval between runs functions.
-  time64 GetTimeSinceLastCoreRunMs(bool is_machine) const;
-  time64 GetLastCoreRunTimeMs(bool is_machine) const;
-  HRESULT SetLastCoreRunTimeMs(bool is_machine, time64 time);
-
   // Code Red check interval functions.
   int GetCodeRedTimerIntervalMs() const;
   time64 GetTimeSinceLastCodeRedCheckMs(bool is_machine) const;

--- a/omaha/core/build.scons
+++ b/omaha/core/build.scons
@@ -41,20 +41,12 @@ core_env['CPPPATH'] += [
     ]
 
 core_env.Append(
-    CCFLAGS = [
-      '/wd5038',
-    ],
     LIBS = [
         'advapi32.lib',
         'crypt32.lib',
-        'delayimp.lib',
         'kernel32.lib',
         'netapi32.lib',
-        'ole32.lib',
         'psapi.lib',
-        'rpcns4.lib',
-        'rpcrt4.lib',
-        'shell32.lib',
         'shlwapi.lib',
         'user32.lib',
         'userenv.lib',
@@ -64,11 +56,8 @@ core_env.Append(
         core_env['atls_libs'][core_env.Bit('debug')],
         core_env['crt_libs'][core_env.Bit('debug')],
         core_env.GetMultiarchLibName('base'),
-        core_env.GetMultiarchLibName('client'),
         core_env.GetMultiarchLibName('common'),
-        core_env.GetMultiarchLibName('core'),
         core_env.GetMultiarchLibName('logging'),
-        core_env.GetMultiarchLibName('omaha3_idl'),
         core_env.GetMultiarchLibName('security'),
         ],
   RCFLAGS = [
@@ -90,7 +79,7 @@ if core_env.Bit('has_device_management'):
 
 google_core_res_target = 'resource.res'
 google_core_res = core_env.RES(source = 'resource.rc',
-                                      target = google_core_res_target)
+                               target = google_core_res_target)
 core_env.Depends(google_core_res, 'GoogleUpdateCore.manifest')
 
 google_core_inputs = [

--- a/omaha/core/build.scons
+++ b/omaha/core/build.scons
@@ -39,22 +39,16 @@ omaha_version_info = core_env['omaha_versions_info'][0]
 core_env['CPPPATH'] += [
     '$OBJ_ROOT',
     ]
+
 core_env.Append(
     CCFLAGS = [
       '/wd5038',
     ],
     LIBS = [
         'advapi32.lib',
-        'bits.lib',
-        'comctl32.lib',
         'crypt32.lib',
         'delayimp.lib',
-        'imagehlp.lib',
-        'iphlpapi.lib',
         'kernel32.lib',
-        'msi.lib',
-        'msimg32.lib',
-        'mstask.lib',
         'netapi32.lib',
         'ole32.lib',
         'psapi.lib',
@@ -62,35 +56,20 @@ core_env.Append(
         'rpcrt4.lib',
         'shell32.lib',
         'shlwapi.lib',
-        'taskschd.lib',
         'user32.lib',
         'userenv.lib',
-        'uxtheme.lib',
         'version.lib',
-        'wininet.lib',
         'wintrust.lib',
-        'ws2_32.lib',
         'wtsapi32.lib',
         core_env['atls_libs'][core_env.Bit('debug')],
         core_env['crt_libs'][core_env.Bit('debug')],
         core_env.GetMultiarchLibName('base'),
-        core_env.GetMultiarchLibName('breakpad'),
         core_env.GetMultiarchLibName('client'),
         core_env.GetMultiarchLibName('common'),
         core_env.GetMultiarchLibName('core'),
-        core_env.GetMultiarchLibName('crash_handler'),
-        core_env.GetMultiarchLibName('crx_file'),
-        core_env.GetMultiarchLibName('google_update_recovery'),
-        core_env.GetMultiarchLibName('goopdate_lib'),
-        core_env.GetMultiarchLibName('libprotobuf'),
         core_env.GetMultiarchLibName('logging'),
-        core_env.GetMultiarchLibName('net'),
         core_env.GetMultiarchLibName('omaha3_idl'),
         core_env.GetMultiarchLibName('security'),
-        core_env.GetMultiarchLibName('service'),
-        core_env.GetMultiarchLibName('setup'),
-        core_env.GetMultiarchLibName('statsreport'),
-        core_env.GetMultiarchLibName('ui'),
         ],
   RCFLAGS = [
       '/DVERSION_MAJOR=%d' % omaha_version_info.version_major,
@@ -115,6 +94,7 @@ google_core_res = core_env.RES(source = 'resource.rc',
 core_env.Depends(google_core_res, 'GoogleUpdateCore.manifest')
 
 google_core_inputs = [
+    'core_launcher.cc',
     'winmain.cc',
     google_core_res,
     ]

--- a/omaha/core/core.cc
+++ b/omaha/core/core.cc
@@ -171,42 +171,6 @@ bool Core::ShouldRunForever() const {
   return result;
 }
 
-bool Core::ShouldRunCore(bool is_system) {
-  ConfigManager* cm = ConfigManager::Instance();
-  const time64 time_difference_ms = cm->GetTimeSinceLastCoreRunMs(is_system);
-
-  const bool result = time_difference_ms >= kMaxWaitBetweenCoreRunsMs;
-  CORE_LOG(L3, (_T("[ShouldRunCore][%d][%llu]"), result, time_difference_ms));
-  return result;
-}
-
-HRESULT Core::UpdateLastCoreRunTime(bool is_system) {
-  const time64 now = GetCurrentMsTime();
-  return ConfigManager::Instance()->SetLastCoreRunTimeMs(is_system, now);
-}
-
-HRESULT Core::StartCoreIfNeeded(bool is_system) {
-  CORE_LOG(L3, (_T("[Core::StartCoreIfNeeded][%d]"), is_system));
-
-  if (!ShouldRunCore(is_system)) {
-    return S_OK;
-  }
-
-  CommandLineBuilder builder(omaha::COMMANDLINE_MODE_CORE);
-  CString cmd_line(builder.GetCommandLineArgs());
-  scoped_process process;
-  HRESULT hr = goopdate_utils::StartGoogleUpdateWithArgs(is_system,
-                                                         cmd_line,
-                                                         address(process));
-  if (FAILED(hr)) {
-    CORE_LOG(LE, (_T("[Unable to start Core][%#x]"), hr));
-    return hr;
-  }
-
-  VERIFY1(SUCCEEDED(UpdateLastCoreRunTime(is_system)));
-  return S_OK;
-}
-
 HRESULT Core::DoMain(bool is_system, bool is_crash_handler_enabled) {
   main_thread_id_ = ::GetCurrentThreadId();
   is_system_ = is_system;

--- a/omaha/core/core.h
+++ b/omaha/core/core.h
@@ -113,9 +113,6 @@ class Core
   // Collects ambient core metrics.
   void CollectMetrics()const;
 
-  static bool ShouldRunCore(bool is_system);
-  static HRESULT UpdateLastCoreRunTime(bool is_system);
-
   HRESULT InitializeScheduler(const Scheduler* scheduler);
 
   bool is_system_;

--- a/omaha/core/core_launcher.cc
+++ b/omaha/core/core_launcher.cc
@@ -1,0 +1,97 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========================================================================
+
+#include "omaha/core/core_launcher.h"
+
+#include <cstdint>
+
+#include "omaha/base/constants.h"
+#include "omaha/base/debug.h"
+#include "omaha/base/reg_key.h"
+#include "omaha/base/logging.h"
+#include "omaha/common/command_line_builder.h"
+#include "omaha/common/goopdate_utils.h"
+#include "omaha/third_party/smartany/scoped_any.h"
+
+namespace omaha {
+
+namespace {
+
+time64 GetLastCoreRunTimeMs(bool is_machine) {
+  const wchar_t* reg_update_key(is_machine ? MACHINE_REG_UPDATE :
+                                             USER_REG_UPDATE);
+  time64 last_core_run_time = 0;
+  if (SUCCEEDED(RegKey::GetValue(reg_update_key,
+                                 kRegValueLastCoreRun,
+                                 &last_core_run_time))) {
+    return last_core_run_time;
+  }
+
+  return 0;
+}
+
+time64 GetTimeSinceLastCoreRunMs(bool is_machine) {
+  const time64 now = GetCurrentMsTime();
+  const time64 last_core_run = GetLastCoreRunTimeMs(is_machine);
+
+  if (now < last_core_run) {
+    return UINT64_MAX;
+  }
+
+  return now - last_core_run;
+}
+
+HRESULT UpdateLastCoreRunTime(bool is_machine) {
+  const time64 now = GetCurrentMsTime();
+  const wchar_t* reg_update_key(is_machine ? MACHINE_REG_UPDATE :
+                                             USER_REG_UPDATE);
+  return RegKey::SetValue(reg_update_key, kRegValueLastCoreRun, now);
+}
+
+} // namespace
+
+
+bool ShouldRunCore(bool is_system) {
+  const time64 time_difference_ms = GetTimeSinceLastCoreRunMs(is_system);
+
+  const bool result = time_difference_ms >= kMaxWaitBetweenCoreRunsMs;
+  CORE_LOG(L3, (L"[ShouldRunCore][%d][%llu]", result, time_difference_ms));
+  return result;
+
+}
+
+HRESULT StartCoreIfNeeded(bool is_system) {
+  CORE_LOG(L3, (L"[Core::StartCoreIfNeeded][%d]", is_system));
+
+  if (!ShouldRunCore(is_system)) {
+    return S_OK;
+  }
+
+  CommandLineBuilder builder(omaha::COMMANDLINE_MODE_CORE);
+  CString cmd_line(builder.GetCommandLineArgs());
+  scoped_process process;
+  HRESULT hr = goopdate_utils::StartGoogleUpdateWithArgs(is_system,
+                                                         cmd_line,
+                                                         address(process));
+  if (FAILED(hr)) {
+    CORE_LOG(LE, (L"[Unable to start Core][%#x]", hr));
+    return hr;
+  }
+
+  VERIFY1(SUCCEEDED(UpdateLastCoreRunTime(is_system)));
+  return S_OK;
+}
+
+} // namespace omaha

--- a/omaha/core/core_launcher.cc
+++ b/omaha/core/core_launcher.cc
@@ -19,8 +19,8 @@
 
 #include "omaha/base/constants.h"
 #include "omaha/base/debug.h"
-#include "omaha/base/reg_key.h"
 #include "omaha/base/logging.h"
+#include "omaha/base/reg_key.h"
 #include "omaha/common/command_line_builder.h"
 #include "omaha/common/goopdate_utils.h"
 #include "omaha/third_party/smartany/scoped_any.h"
@@ -30,11 +30,10 @@ namespace omaha {
 namespace {
 
 time64 GetLastCoreRunTimeMs(bool is_machine) {
-  const wchar_t* reg_update_key(is_machine ? MACHINE_REG_UPDATE :
-                                             USER_REG_UPDATE);
+  const wchar_t* reg_update_key(is_machine ? MACHINE_REG_UPDATE
+                                           : USER_REG_UPDATE);
   time64 last_core_run_time = 0;
-  if (SUCCEEDED(RegKey::GetValue(reg_update_key,
-                                 kRegValueLastCoreRun,
+  if (SUCCEEDED(RegKey::GetValue(reg_update_key, kRegValueLastCoreRun,
                                  &last_core_run_time))) {
     return last_core_run_time;
   }
@@ -55,13 +54,12 @@ time64 GetTimeSinceLastCoreRunMs(bool is_machine) {
 
 HRESULT UpdateLastCoreRunTime(bool is_machine) {
   const time64 now = GetCurrentMsTime();
-  const wchar_t* reg_update_key(is_machine ? MACHINE_REG_UPDATE :
-                                             USER_REG_UPDATE);
+  const wchar_t* reg_update_key(is_machine ? MACHINE_REG_UPDATE
+                                           : USER_REG_UPDATE);
   return RegKey::SetValue(reg_update_key, kRegValueLastCoreRun, now);
 }
 
-} // namespace
-
+}  // namespace
 
 bool ShouldRunCore(bool is_system) {
   const time64 time_difference_ms = GetTimeSinceLastCoreRunMs(is_system);
@@ -69,7 +67,6 @@ bool ShouldRunCore(bool is_system) {
   const bool result = time_difference_ms >= kMaxWaitBetweenCoreRunsMs;
   CORE_LOG(L3, (L"[ShouldRunCore][%d][%llu]", result, time_difference_ms));
   return result;
-
 }
 
 HRESULT StartCoreIfNeeded(bool is_system) {
@@ -82,8 +79,7 @@ HRESULT StartCoreIfNeeded(bool is_system) {
   CommandLineBuilder builder(omaha::COMMANDLINE_MODE_CORE);
   CString cmd_line(builder.GetCommandLineArgs());
   scoped_process process;
-  HRESULT hr = goopdate_utils::StartGoogleUpdateWithArgs(is_system,
-                                                         cmd_line,
+  HRESULT hr = goopdate_utils::StartGoogleUpdateWithArgs(is_system, cmd_line,
                                                          address(process));
   if (FAILED(hr)) {
     CORE_LOG(LE, (L"[Unable to start Core][%#x]", hr));
@@ -94,4 +90,4 @@ HRESULT StartCoreIfNeeded(bool is_system) {
   return S_OK;
 }
 
-} // namespace omaha
+}  // namespace omaha

--- a/omaha/core/core_launcher.h
+++ b/omaha/core/core_launcher.h
@@ -22,7 +22,7 @@
 
 namespace omaha {
 
-static bool ShouldRunCore(bool is_system);
+bool ShouldRunCore(bool is_system);
 
 HRESULT StartCoreIfNeeded(bool is_system);
 

--- a/omaha/core/core_launcher.h
+++ b/omaha/core/core_launcher.h
@@ -1,0 +1,31 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========================================================================
+
+// Launches the core process by starting the shell exe with /c argument
+
+#ifndef OMAHA_CORE_CORE_LAUNCHER_H_
+#define OMAHA_CORE_CORE_LAUNCHER_H_
+
+#include <winerror.h>
+
+namespace omaha {
+
+static bool ShouldRunCore(bool is_system);
+
+HRESULT StartCoreIfNeeded(bool is_system);
+
+}  // namespace omaha
+
+#endif  // OMAHA_CORE_CORE_LAUNCHER_H_

--- a/omaha/core/core_unittest.cc
+++ b/omaha/core/core_unittest.cc
@@ -29,6 +29,7 @@
 #include "omaha/common/goopdate_utils.h"
 #include "omaha/common/scheduled_task_utils.h"
 #include "omaha/core/core.h"
+#include "omaha/core/core_launcher.h"
 #include "omaha/goopdate/app_command_test_base.h"
 #include "omaha/setup/setup_service.h"
 #include "omaha/testing/unit_test.h"
@@ -242,7 +243,7 @@ class CoreUtilsTest : public testing::Test {
   }
 
   bool ShouldRunCore() {
-    return Core::ShouldRunCore(is_machine_);
+    return omaha::ShouldRunCore(is_machine_);
   }
 
   bool ShouldRunCodeRed() {

--- a/omaha/core/winmain.cc
+++ b/omaha/core/winmain.cc
@@ -14,12 +14,12 @@
 // ========================================================================
 
 #include <windows.h>
-#include <tchar.h>
-#include <cstringt.h>
-#include "omaha/base/omaha_version.h"
-#include "omaha/core/core.h"
 
-int WINAPI _tWinMain(HINSTANCE, HINSTANCE, LPTSTR, int) {
+#include "omaha/base/omaha_version.h"
+#include "omaha/base/utils.h"
+#include "omaha/core/core_launcher.h"
+
+int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int) {
   omaha::EnableSecureDllLoading();
 
   scoped_co_init init_com_apt(COINIT_MULTITHREADED);
@@ -36,5 +36,5 @@ int WINAPI _tWinMain(HINSTANCE, HINSTANCE, LPTSTR, int) {
     return hr;
   }
 
-  return omaha::Core::StartCoreIfNeeded(is_system);
+  return omaha::StartCoreIfNeeded(is_system);
 }

--- a/omaha/testing/build.scons
+++ b/omaha/testing/build.scons
@@ -455,6 +455,7 @@ omaha_unittest_inputs = [
     '../crashhandler/crash_analyzer_unittest.cc',
 
     # Core unit tests
+    '../core/core_launcher.cc',
     '../core/core_unittest.cc',
     '../core/scheduler_unittest.cc',
     '../core/system_monitor_unittest.cc',


### PR DESCRIPTION
Extract code that is needed for GoogleUpdateCore.exe to launch GoogleUpdate.exe /c. 
This change reduces unnecessary linkage in the Core executable.

Size on disk before:
```
1,170,024 GoogleUpdateSetup.exe
344,408 GoogleUpdateCore.exe
```
after:
```
1,158,760 GoogleUpdateSetup.exe   ( - 11,264 /  -1% )
213,848 GoogleUpdateCore.exe ( - 130,560  / - 38%)
```