### PR TITLE
Fix build errors with VS 16.4

### DIFF
--- a/omaha/base/process.cc
+++ b/omaha/base/process.cc
@@ -159,7 +159,7 @@ bool Process::Running() const {
 HANDLE Process::AssignToJob() {
   // Make sure that the process handle is valid
   if (!get(process_)) {
-    return false;
+    return nullptr;
   }
 
   // Create a job
@@ -168,7 +168,7 @@ HANDLE Process::AssignToJob() {
     UTIL_LOG(LEVEL_ERROR,
              (_T("[Process::AssignToJob - CreateJobObject failed][0x%x]"),
               HRESULTFromLastError()));
-    return false;
+    return nullptr;
   }
 
   // Assign the process to the job
@@ -176,7 +176,7 @@ HANDLE Process::AssignToJob() {
     UTIL_LOG(LEVEL_ERROR,
              (_T("[Process::AssignToJob-AssignProcessToJobObject fail][0x%x]"),
               HRESULTFromLastError()));
-    return false;
+    return nullptr;
   }
 
   return release(job);

--- a/omaha/goopdate/ondemand.h
+++ b/omaha/goopdate/ondemand.h
@@ -31,6 +31,7 @@
 #include "omaha/base/scope_guard.h"
 #include "omaha/base/synchronized.h"
 #include "omaha/base/thread_pool_callback.h"
+#include "omaha/base/user_rights.h"
 #include "omaha/base/utils.h"
 #include "omaha/common/const_goopdate.h"
 #include "omaha/goopdate/com_proxy.h"

--- a/omaha/third_party/smartany/scoped_any.h
+++ b/omaha/third_party/smartany/scoped_any.h
@@ -118,7 +118,7 @@ public:
     {
         static detail::smartany_static_assert<!detail::is_handle<T>::value> const cannot_dereference_a_handle;
         assert( valid() );
-        return smart_types::to_reference( m_t );
+        return safe_types::to_reference( m_t );
     }
     #endif
 


### PR DESCRIPTION
- Fix bool to HANDLE conversion in base/process.cc
- Fix missing header in goopdate/ondemand.h 
- Fix wrong template type in smart_any.h

Note: Omaha still doesn't build with `/permissive-` mode in 16.4 due to a bug in atlenc.h.