### PR TITLE
Log secure status flag for WININET_E_DECODING_FAILED

### DIFF
--- a/omaha/net/winhttp_adapter.h
+++ b/omaha/net/winhttp_adapter.h
@@ -26,6 +26,8 @@
 
 namespace omaha {
 
+class WinHttpAdapterTest;
+
 // Provides a sync-async adapter between the caller and the asynchronous
 // WinHttp client. Solves the issue of reliably canceling of WinHttp calls by
 // closing the handles and avoding the race condition between handle closing
@@ -114,6 +116,9 @@ class WinHttpAdapter {
 
   CString server_name() const { return server_name_; }
   CString server_ip() const { return server_ip_; }
+  DWORD secure_status_flag() const { return secure_status_flag_; }
+
+  HRESULT GetErrorFromSecureStatusFlag() const;
 
  private:
 
@@ -146,10 +151,13 @@ class WinHttpAdapter {
   DWORD                  async_bytes_read_;
   scoped_event           async_completion_event_;
   scoped_event           async_handle_closing_event_;
+  DWORD                  secure_status_flag_;
 
   LLock                  lock_;
 
   DISALLOW_COPY_AND_ASSIGN(WinHttpAdapter);
+
+  friend class WinHttpAdapterTest;
 };
 
 }  // namespace omaha

--- a/omaha/net/winhttp_adapter_unittest.cc
+++ b/omaha/net/winhttp_adapter_unittest.cc
@@ -92,4 +92,54 @@ TEST(WinHttpAdapter, OpenRequestClose) {
   EXPECT_HRESULT_SUCCEEDED(http_client->Close(session_handle));
 }
 
+class WinHttpAdapterTest : public testing::Test {
+public:
+ WinHttpAdapterTest() {}
+protected:
+ void SetSecureStatus(WinHttpAdapter* adapter, uint32_t flag) {
+   adapter->secure_status_flag_ = flag;
+ }
+};
+
+TEST_F(WinHttpAdapterTest, ErrorFromSecureStatusFlag) {
+  WinHttpAdapter winhttp_adapter;
+  EXPECT_HRESULT_SUCCEEDED(winhttp_adapter.GetErrorFromSecureStatusFlag());
+
+  SetSecureStatus(&winhttp_adapter,
+                  WINHTTP_CALLBACK_STATUS_FLAG_CERT_REV_FAILED);
+  EXPECT_EQ(winhttp_adapter.GetErrorFromSecureStatusFlag(),
+            HRESULT_FROM_WIN32(ERROR_WINHTTP_SECURE_CERT_REV_FAILED));
+
+  SetSecureStatus(&winhttp_adapter, WINHTTP_CALLBACK_STATUS_FLAG_INVALID_CERT);
+  EXPECT_EQ(winhttp_adapter.GetErrorFromSecureStatusFlag(),
+            HRESULT_FROM_WIN32(ERROR_WINHTTP_SECURE_INVALID_CERT));
+
+  SetSecureStatus(&winhttp_adapter, WINHTTP_CALLBACK_STATUS_FLAG_CERT_REVOKED);
+  EXPECT_EQ(winhttp_adapter.GetErrorFromSecureStatusFlag(),
+            HRESULT_FROM_WIN32(ERROR_WINHTTP_SECURE_CERT_REVOKED));
+
+  SetSecureStatus(&winhttp_adapter, WINHTTP_CALLBACK_STATUS_FLAG_INVALID_CA);
+  EXPECT_EQ(winhttp_adapter.GetErrorFromSecureStatusFlag(),
+            HRESULT_FROM_WIN32(ERROR_WINHTTP_SECURE_INVALID_CA));
+
+  SetSecureStatus(&winhttp_adapter,
+                  WINHTTP_CALLBACK_STATUS_FLAG_CERT_CN_INVALID);
+  EXPECT_EQ(winhttp_adapter.GetErrorFromSecureStatusFlag(),
+            HRESULT_FROM_WIN32(ERROR_WINHTTP_SECURE_CERT_CN_INVALID));
+
+  SetSecureStatus(&winhttp_adapter,
+                  WINHTTP_CALLBACK_STATUS_FLAG_CERT_DATE_INVALID);
+  EXPECT_EQ(winhttp_adapter.GetErrorFromSecureStatusFlag(),
+            HRESULT_FROM_WIN32(ERROR_WINHTTP_SECURE_CERT_DATE_INVALID));
+
+  SetSecureStatus(&winhttp_adapter,
+                  WINHTTP_CALLBACK_STATUS_FLAG_SECURITY_CHANNEL_ERROR);
+  EXPECT_EQ(winhttp_adapter.GetErrorFromSecureStatusFlag(),
+            HRESULT_FROM_WIN32(ERROR_WINHTTP_SECURE_CHANNEL_ERROR));
+
+  // Not a valid WINHTTP_CALLBACK_STATUS_FLAG_* value.
+  SetSecureStatus(&winhttp_adapter, 0x00000400);
+  EXPECT_HRESULT_SUCCEEDED(winhttp_adapter.GetErrorFromSecureStatusFlag());
+}
+
 }  // namespace omaha


### PR DESCRIPTION
Log secure status flag for WININET_E_DECODING_FAILED - on Win 7 this error can happen when you change time and the cert trust cannot be verified. We can make this error more actionable by logging WinHTTP status.

The unforunate fact is that `WININET_E_DECODING_FAILED`  is equivalent to `HRESULT_FROM_WIN32(ERROR_INTERNET_DECODING_FAILED)` as well as `HRESULT(ERROR_WINHTTP_SECURE_FAILURE)` and you can't tell the two.