### PR TITLE
Increase the delta in DeleteSoonBeforeCallbackExpires to 50ms

### DIFF
--- a/omaha/core/scheduler_unittest.cc
+++ b/omaha/core/scheduler_unittest.cc
@@ -102,7 +102,7 @@ TEST_F(SchedulerTest, DeleteWhenCallbackExpires) {
 TEST_F(SchedulerTest, DeleteSoonBeforeCallbackExpires) {
   int call_count = 0;
   constexpr int kInterval = 500;
-  constexpr int kTimeout = kInterval - 10;
+  constexpr int kTimeout = kInterval - 50;
   scoped_handle callback_fired(::CreateEvent(NULL, true, false, NULL));
   {
     Scheduler scheduler;


### PR DESCRIPTION
The SchedulerTest.DeleteSoonBeforeCallbackExpires seems flaky. The 10ms difference between the scheduler interval and the timeout sometimes isn't enough. Increase the delta to 50ms.