### PR TITLE
Initialize COM with COINIT_DISABLE_OLE1DDE 

### DIFF
--- a/omaha/third_party/smartany/smart_any_fwd.h
+++ b/omaha/third_party/smartany/smart_any_fwd.h
@@ -1022,7 +1022,9 @@ typedef close_fun<pfn_free_t,static_cast<pfn_free_t>(&free)>                clos
   {
       (void) dwCoInit;
 #     if (_WIN32_WINNT >= 0x0400 ) | defined(_WIN32_DCOM)
-          return ::CoInitializeEx(0,dwCoInit);
+          // COINIT_DISABLE_OLE1DDE is always added based on:
+          // https://docs.microsoft.com/en-us/windows/desktop/learnwin32/initializing-the-com-library
+          return ::CoInitializeEx(0, dwCoInit | COINIT_DISABLE_OLE1DDE);
 #     else
           return ::CoInitialize(0);
 #     endif


### PR DESCRIPTION
As noticed in the Chromium code, we can disable the legacy feature by passing COINIT_DISABLE_OLE1DDE to CoInitializeEx.