### PR TITLE
Use LOAD_LIBRARY_SEARCH_SYSTEM32 when loading system libs

### DIFF
--- a/omaha/base/app_util_unittest.cc
+++ b/omaha/base/app_util_unittest.cc
@@ -71,7 +71,8 @@ TEST(AppUtilTest, AppUtil) {
   // Use kernel32.dll
 
   // Get the loading address of kernel32.
-  HMODULE kernel32Module = ::LoadLibrary(kKernel32Name);
+  HMODULE kernel32Module =
+      ::LoadLibraryEx(kKernel32Name, nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
   EXPECT_TRUE(kernel32Module != NULL);
 
   // Test the dll module handle using an address.
@@ -90,7 +91,8 @@ TEST(AppUtilTest, AppUtil) {
 
   // DLL versioning.
   // For the tests to succeed, shell32.dll must be loaded in memory.
-  HMODULE shell32Module = ::LoadLibrary(kShell32Name);
+  HMODULE shell32Module =
+      ::LoadLibraryEx(kShell32Name, nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
   EXPECT_NE(0, DllGetVersion(GetSystemDir() + L"\\" + kShell32Name));
   EXPECT_NE(0, DllGetVersion(kShell32Name));
   EXPECT_NE(0, SystemDllGetVersion(kShell32Name));
@@ -98,7 +100,8 @@ TEST(AppUtilTest, AppUtil) {
   // For the tests to succeed, comctl32.dll must be loaded in memory.
   // ComCtl32 may be loaded from a side-by-side (WinSxS) directory, so it is not
   // practical to do a full-path or SystemDllGetVersion test with it.
-  HMODULE comctl32_module = ::LoadLibrary(kComCtl32Name);
+  HMODULE comctl32_module =
+      ::LoadLibraryEx(kComCtl32Name, nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
   EXPECT_NE(0, DllGetVersion(kComCtl32Name));
 
   // kernel32 does not export DllGetVersion.
@@ -145,7 +148,8 @@ TEST(AppUtilTest, GetModuleHandleFromAddress) {
   EXPECT_EQ(GetModuleHandle(NULL), module);
 
   // Get the address of a function in kernel32.
-  HMODULE kernel32_module = ::LoadLibrary(_T("kernel32"));
+  HMODULE kernel32_module =
+      ::LoadLibraryEx(_T("kernel32"), nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
   ASSERT_TRUE(kernel32_module);
 
   HMODULE readfile_module = GetModuleHandleFromAddress(

--- a/omaha/base/system_info.cc
+++ b/omaha/base/system_info.cc
@@ -150,7 +150,8 @@ bool SystemInfo::Is64BitWindows() {
 HRESULT SystemInfo::GetOSVersion(OSVERSIONINFOEX* os_out) {
   ASSERT1(os_out);
 
-  scoped_library ntdll(::LoadLibrary(_T("ntdll.dll")));
+  scoped_library ntdll(
+      ::LoadLibraryEx(_T("ntdll.dll"), nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
   if (!ntdll) {
     return HRESULTFromLastError();
   }

--- a/omaha/base/utils.h
+++ b/omaha/base/utils.h
@@ -177,8 +177,9 @@ bool GPA(HMODULE module, const char* function_name, T* function_pointer) {
                  result_error)                                              \
 typedef result_type (calling_convention *function##_pointer) proto;         \
 inline result_type function##Wrap proto {                                   \
-  scoped_library dll(::LoadLibrary(_T(#module)));                           \
-  ASSERT1(dll);                                                             \
+  scoped_library dll(::LoadLibraryEx(_T(#module), nullptr,                  \
+                                     LOAD_LIBRARY_SEARCH_SYSTEM32));        \
+  ASSERT(dll, (_T("::GetLastError[%d]"), ::GetLastError()));                \
   if (!dll) {                                                               \
     return result_error;                                                    \
   }                                                                         \

--- a/omaha/common/goopdate_utils.cc
+++ b/omaha/common/goopdate_utils.cc
@@ -681,7 +681,8 @@ HRESULT RegisterTypeLibForUser(ITypeLib* lib,
   // help_dir can be NULL.
 
   const TCHAR* library_name = _T("oleaut32.dll");
-  scoped_library module(static_cast<HINSTANCE>(::LoadLibrary(library_name)));
+  scoped_library module(static_cast<HINSTANCE>(
+      ::LoadLibraryEx(library_name, nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32)));
   if (!module) {
     HRESULT hr = HRESULTFromLastError();
     CORE_LOG(LEVEL_ERROR,
@@ -720,7 +721,8 @@ HRESULT UnRegisterTypeLibForUser(REFGUID lib_id,
   CORE_LOG(L3, (_T("[UnRegisterTypeLibForUser]")));
 
   const TCHAR* library_name = _T("oleaut32.dll");
-  scoped_library module(static_cast<HINSTANCE>(::LoadLibrary(library_name)));
+  scoped_library module(static_cast<HINSTANCE>(
+      ::LoadLibraryEx(library_name, nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32)));
   if (!module) {
     HRESULT hr = HRESULTFromLastError();
     CORE_LOG(LEVEL_ERROR,

--- a/omaha/crashhandler/crash_analyzer_checks.cc
+++ b/omaha/crashhandler/crash_analyzer_checks.cc
@@ -92,8 +92,10 @@ CrashAnalysisResult NtFunctionsOnStack::Run() {
   // Because the crash handler process is running on the same system
   // as the process which crashed we can assume that they are mapped
   // in the same location in both processes.
-  HMODULE ntdll = ::LoadLibraryA("ntdll.dll");
-  HMODULE kernel32 = ::LoadLibraryA("kernel32.dll");
+  HMODULE ntdll =
+      ::LoadLibraryExA("ntdll.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+  HMODULE kernel32 =
+      ::LoadLibraryExA("kernel32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
   std::vector<BYTE*> functions;
   functions.push_back(reinterpret_cast<BYTE*>(
       ::GetProcAddress(kernel32, "HeapCreate")));

--- a/omaha/crashhandler/crash_analyzer_debugee_test.cc
+++ b/omaha/crashhandler/crash_analyzer_debugee_test.cc
@@ -43,7 +43,8 @@ void MaxExecMappings() {
 }
 
 void NtFunctionsOnStack() {
-  HMODULE ntdll = ::LoadLibraryA("ntdll.dll");
+  HMODULE ntdll =
+      ::LoadLibraryExA("ntdll.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
   FARPROC ptr = ::GetProcAddress(ntdll, "ZwProtectVirtualMemory");
   AwaitTheReaper();
 }
@@ -62,7 +63,8 @@ void TestWildStackPointer() {
 
 void TestPENotInModuleList() {
   MEMORY_BASIC_INFORMATION mbi = {0};
-  BYTE* ntdll = reinterpret_cast<BYTE*>(::LoadLibraryA("ntdll.dll"));
+  BYTE* ntdll = reinterpret_cast<BYTE*>(
+      ::LoadLibraryExA("ntdll.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
   ::VirtualQuery(ntdll, &mbi, sizeof(mbi));
   LPVOID buffer = ::VirtualAlloc(NULL,
                                  mbi.RegionSize,

--- a/omaha/goopdate/cred_dialog.cc
+++ b/omaha/goopdate/cred_dialog.cc
@@ -86,7 +86,8 @@ DWORD CredentialDialogBase::DisplayDialog(
     LPCTSTR caption,
     CString* username_out,
     CString* password_out) {
-  scoped_library credui_lib(::LoadLibrary(L"credui.dll"));
+  scoped_library credui_lib(
+      ::LoadLibraryExW(L"credui.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
   ASSERT1(credui_lib);
   if (!credui_lib) {
     CORE_LOG(L3, (_T("[CredUIPromptForCredentialsW not available]")));

--- a/omaha/net/network_config.cc
+++ b/omaha/net/network_config.cc
@@ -601,7 +601,8 @@ GPA_WRAP(jsproxy.dll,
 HRESULT NetworkConfig::GetProxyForUrlLocal(const CString& url,
                                            const CString& path_to_pac_file,
                                            HttpClient::ProxyInfo* proxy_info) {
-  scoped_library jsproxy_lib(::LoadLibrary(_T("jsproxy.dll")));
+  scoped_library jsproxy_lib(::LoadLibraryEx(_T("jsproxy.dll"), nullptr,
+                                             LOAD_LIBRARY_SEARCH_SYSTEM32));
   ASSERT1(jsproxy_lib);
   if (!jsproxy_lib) {
     HRESULT hr = HRESULTFromLastError();

--- a/omaha/net/proxy_auth.cc
+++ b/omaha/net/proxy_auth.cc
@@ -248,7 +248,8 @@ HRESULT ProxyAuth::SetProxyAuthScheme(const CString& proxy_server,
 // This approach (the key in particular) comes from a securityfocus posting:
 // http://www.securityfocus.com/archive/1/458115/30/0/threaded
 bool ProxyAuth::ReadFromIE7(const CString& server) {
-  scoped_library crypt_lib(::LoadLibrary(L"crypt32.dll"));
+  scoped_library crypt_lib(
+      ::LoadLibraryExW(L"crypt32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
   ASSERT1(crypt_lib);
   if (!crypt_lib)
     return false;
@@ -264,7 +265,8 @@ bool ProxyAuth::ReadFromIE7(const CString& server) {
 
   // Load CredEnumerate and CredFree dynamically because they don't exist on
   // Win2K and so loading the GoogleDesktopCommon.dll otherwise.
-  scoped_library advapi_lib(::LoadLibrary(L"advapi32.dll"));
+  scoped_library advapi_lib(
+      ::LoadLibraryExW(L"advapi32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
   ASSERT1(advapi_lib);
   if (!advapi_lib)
     return false;
@@ -339,7 +341,8 @@ bool ProxyAuth::ReadFromIE7(const CString& server) {
 // reading credentials from the IE6 is not supported anymore.
 bool ProxyAuth::ReadFromPreIE7(const CString& server) {
 #if (_MSC_VER < 1800)
-  scoped_library pstore_lib(::LoadLibrary(L"pstorec.dll"));
+  scoped_library pstore_lib(
+      ::LoadLibraryExW(L"pstorec.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
   ASSERT1(pstore_lib);
   if (!pstore_lib)
     return false;

--- a/omaha/net/winhttp_vtable.cc
+++ b/omaha/net/winhttp_vtable.cc
@@ -22,9 +22,11 @@ bool WinHttpVTable::Load() {
     return true;
   }
   Clear();
-  library_ = ::LoadLibrary(_T("winhttp"));
+  library_ =
+      ::LoadLibraryEx(_T("winhttp"), nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (!library_) {
-    library_ = ::LoadLibrary(_T("winhttp5"));
+    library_ =
+        ::LoadLibraryEx(_T("winhttp5"), nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (!library_) {
       return false;
     }

--- a/omaha/tools/goopdump/process_commandline.cc
+++ b/omaha/tools/goopdump/process_commandline.cc
@@ -93,7 +93,8 @@ HRESULT GetCommandLineFromHandleWithMemory(HANDLE process_handle,
   }
 
   // Initialize data area for remote process.
-  scoped_library hmodule_kernel32(::LoadLibrary(L"kernel32.dll"));
+  scoped_library hmodule_kernel32(
+      ::LoadLibraryEx(L"kernel32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
   if (!hmodule_kernel32) {
     return HRESULTFromLastError();
   }


### PR DESCRIPTION
When loading system DLLs, use `LoadLibraryEx` with `LOAD_LIBRARY_SEARCH_SYSTEM32` flag to scope to loading dlls from %windir%\System32 directory only.