### PR TITLE
Fix Core::AreScheduledTasksHealthy on Windows 7

### DIFF
--- a/omaha/common/scheduled_task_utils.cc
+++ b/omaha/common/scheduled_task_utils.cc
@@ -1232,6 +1232,11 @@ bool IsDisabledGoopdateTaskUA(bool is_machine) {
   return internal::Instance().IsDisabledScheduledTask(task_name);
 }
 
+bool HasGoopdateTaskEverRunUA(bool is_machine) {
+  const CString& task_name(internal::GetCurrentTaskNameUA(is_machine));
+  return internal::Instance().HasScheduledTaskEverRun(task_name);
+}
+
 HRESULT GetExitCodeGoopdateTaskUA(bool is_machine) {
   const CString& task_name(internal::GetCurrentTaskNameUA(is_machine));
   return internal::Instance().GetScheduledTaskExitCode(task_name);

--- a/omaha/common/scheduled_task_utils.h
+++ b/omaha/common/scheduled_task_utils.h
@@ -41,6 +41,8 @@ HRESULT UninstallLegacyGoopdateTasks(bool is_machine);
 HRESULT StartGoopdateTaskCore(bool is_machine);
 bool IsInstalledGoopdateTaskUA(bool is_machine);
 bool IsDisabledGoopdateTaskUA(bool is_machine);
+bool HasGoopdateTaskEverRunUA(bool is_machine);
+
 HRESULT GetExitCodeGoopdateTaskUA(bool is_machine);
 bool IsUATaskHealthy(bool is_machine);
 

--- a/omaha/core/core.cc
+++ b/omaha/core/core.cc
@@ -110,7 +110,13 @@ bool Core::AreScheduledTasksHealthy() const {
   HRESULT ua_task_last_exit_code =
       scheduled_task_utils::GetExitCodeGoopdateTaskUA(is_system_);
 
-  if (ua_task_last_exit_code == SCHED_S_TASK_HAS_NOT_RUN &&
+  // On Windows 10, we can rely on the last exit code to be SCHED_S_TASK_HAS_NOT_RUN.
+  // On Windows 7, we cannot, so we fallback to checking the last run time.
+  const bool ua_task_has_not_run =
+    ua_task_last_exit_code == SCHED_S_TASK_HAS_NOT_RUN ||
+    !scheduled_task_utils::HasGoopdateTaskEverRunUA(is_system_);
+
+  if (ua_task_has_not_run &&
       !ConfigManager::Is24HoursSinceLastUpdate(is_system_)) {
     // Not 24 hours yet since install or update. Let us give the UA task the
     // benefit of the doubt, and assume all is well for right now.


### PR DESCRIPTION
## The problem

The behavior of `scheduled_task_utils::GetExitCodeGoopdateTaskUA` is slightly different on Windows 7 which causes AreScheduledTasksHealthy to return false, even when things are fine.

The impact on Win7 is that, since we incorrectly determine that the scheduled tasks are unhealthy, we decide that we `Core::ShouldRunForever()` and we fallback to the infinite restart Scheduler/SystemMonitor approach. I'm not familiar with the implications of that, but I assume it's worse than using the scheduled tasks. Also, this behavior causes the test `CoreUtilsTest.AreScheduledTasksHealthy` to fail on Win7. With this patch, the test passes on Win7.

The subtle difference is:

- on Win10, if the UA task has never run before, then its "last task result" is initialized to 0x41303 SCHED_S_TASK_HAS_NOT_RUN. This gets interpreted correctly by `Core::AreScheduledTasksUnhealthy`.
- on Win7, if the UA task has never run before, then its "last task result" is initialized to 0x1. This gets interpreted as "some code which is not SCHED_S_TASK_HAS_NOT_RUN", and we assume it HAS run before, and that it failed on its last run, and that 0x1 is the error code. The function never finds out that the task hasn't ever run. Instead it reports that the UA task is unhealthy based on the 0x1 last task result.

## The fix

The solution here is to find out if the task has ever run using `get_LastRunTime` rather than `get_LastTaskResult`. This has consistent, correct behavior on both Win10 and Win7. There is existing functionality for this, but is not exposed outside of scheduled_task_utils_internal.h. That functionality is already being tested implicitly in scheduled_task_utils_unittest.cc. The specific change here is to add a public wrapper method, and then use it in `Core::AreScheduledTasksHealthy()`.

On Windows 10, if `get_LastTaskResult` already returned SCHED_S_TASK_HAS_NOT_RUN, we skip the extra call entirely. So, there's no performance hit on Win10.

## Repro steps

Build either dbg-win or opt-win, copy the staging directory to a Win7 VM, then
```
./dbg-win/staging/omaha_unittest.exe --gtest_filter=CoreUtilsTest.AreScheduledTasksHealthy
```

On latest master, this test will fail. On this branch, it will pass.