### PR TITLE
PingTest.BuildOmahaPing: clean up shell exe after test

### DIFF
--- a/omaha/common/ping_test.cc
+++ b/omaha/common/ping_test.cc
@@ -137,7 +137,7 @@ TEST_F(PingTest, BuildOmahaPing) {
   EXPECT_NE(-1, actual_ping_request.Find(expected_ping_request_substring));
 
   // Clean up after ourselves, since we copied the test exe into this path earlier in this test.
-  File::Remove(goopdate_utils::BuildGoogleUpdateExePath(false));
+  EXPECT_SUCCEEDED(File::Remove(goopdate_utils::BuildGoogleUpdateExePath(false)));
 }
 
 TEST_F(PingTest, BuildAppsPing) {

--- a/omaha/common/ping_test.cc
+++ b/omaha/common/ping_test.cc
@@ -135,6 +135,9 @@ TEST_F(PingTest, BuildOmahaPing) {
 
   EXPECT_NE(-1, actual_ping_request.Find(expected_shell_version_substring));
   EXPECT_NE(-1, actual_ping_request.Find(expected_ping_request_substring));
+
+  // Clean up after ourselves, since we copied the test exe into this path earlier in this test.
+  File::Remove(goopdate_utils::BuildGoogleUpdateExePath(false));
 }
 
 TEST_F(PingTest, BuildAppsPing) {


### PR DESCRIPTION
## The problem

The bug here is that `PingTest.BuildOmahaPing` copies a shell exe into the Google Update exe path, then neglects to delete it when it's done. 

This leads to strange interactions with other tests which interact with the shell exe, like the `ShouldInstall_*` tests in `setup_unittest.cc`. Most of those tests start off by copying the build output into the Google Update directory, including the shell exe. But, they copy with `replace_existing_file=false`, so they don't overwrite if there's a file already there.

In particular, `SetupRegistryProtectedUserTest.ShouldInstall_NewerVersion` expects to have the current version of the shell exe available. There's also a different setup test which deletes the shell exe: `SetupRegistryProtectedUserTest.ShouldInstall_NewerVersionShellMissing`. So depending on the test execution order, it's possible for ShouldInstall_NewerVersion to run an unexpected version of the shell exe and fail.

## The fix

Delete the shell exe at the end of the ping test with `File::Remove`.

## Repro steps

Build for either dbg-win or opt-win, then on a Windows 10 VM. Then run the three tests repeatedly with `--gtest_shuffle`.

```
./dbg-win/staging/omaha_unittest.exe --gtest_filter=PingTest.BuildOmahaPing:SetupRegistryProtectedUserTest.ShouldInstall_NewerVersion:SetupRegistryProtectedUserTest.ShouldInstall_NewerVersionShellMissing --gtest_shuffle --gtest_repeat=5
```

On latest master, `SetupRegistryProtectedUserTest.ShouldInstall_NewerVersion` will fail some of the time.

On this branch, all tests pass on every run.