### PR TITLE
Single-sign test MSIs

### DIFF
--- a/omaha/test/build.scons
+++ b/omaha/test/build.scons
@@ -128,7 +128,8 @@ def BuildMSI(version, namespace, exe_name, wxs_template, msi_base_name,
 
   wix_env.Depends(unsigned_msi, additional_dependencies)
 
-  signed_output = env.DualSignedBinary(
+  # Single-signed here because it is not possible to dual-sign an msi.
+  signed_output = env.SignedBinary(
       target=msi_base_name + '.msi',
       source=unsigned_msi,
   )


### PR DESCRIPTION
This part of omaha/test/build.scons throws errors during the build. It complains that SignTool.exe does not support dual-signing for MSIs.

    python C:\Omaha\src\omaha/tools/retry.py 10 5 "C:\Omaha\depot_tools\win_toolchain\vs_files\c3f20336a802feafb047f13730eed8b7d7fedb62\win_sdk\bin\10.0.19041.0\x86/signtool.exe" sign /v /f "C:\Omaha\src\omaha/data/Sha2OmahaTestCert.pfx" /p "888" /tr "http://timestamp.digicert.com" /td "SHA256" /as /fd "SHA256" "scons-out\dbg-win\obj\test\enterprise_test_foo_v1.0.101.0.msi"

    SignTool Error: Multiple signature support is not implemented for this filetype.
    SignTool Error: An error occurred while attempting to sign: scons-out\dbg-win\obj\test\enterprise_test_foo_v1.0.101.0.msi

We don't actually use this behavior downstream on Edge but I thought I'd send a PR in case this is an issue upstream as well.

References:
- https://stackoverflow.com/questions/18542160/signtool-failing-to-dual-sign-sha2-and-sha1-with-timestamps
- https://social.msdn.microsoft.com/forums/windowsdesktop/en-us/d4b70ecd-a883-4289-8047-cc9cde28b492/sha1-sha256-dualsigning-for-msi?forum=windowssecurity