### PR TITLE
MsiTagExtractorTest: direct path to unittest_support files 

### DIFF
--- a/omaha/enterprise/installer/custom_actions/msi_tag_extractor_test.cc
+++ b/omaha/enterprise/installer/custom_actions/msi_tag_extractor_test.cc
@@ -33,7 +33,7 @@ class MsiTagExtractorTest : public testing::Test {
   virtual void SetUp() {
     unittest_file_path_ = app_util::GetModuleDirectory(NULL);
     EXPECT_TRUE(::PathAppend(CStrBuf(unittest_file_path_, MAX_PATH),
-                             _T("..\\staging\\unittest_support\\tagged_msi")));
+                             _T("unittest_support\\tagged_msi")));
     EXPECT_TRUE(File::Exists(unittest_file_path_));
   }
 


### PR DESCRIPTION
These tests assume that `omaha_unittest.exe` will always be run directly from a folder named `staging/`. Although this is true by default, it's not a guarantee. In some CI environments, build output is packaged up and copied into a directory with a different name e.g. `test_bin/`. That breaks these tests since now the path `../staging/unittest_support/tagged_msi` no longer exists.

The fix is to reference the folder directly like `./unittest_support`, instead of `../staging/unittest_support`.

Repro:

```powershell
# Build dbg-win
# --build_server needed to build enterprise module, which builds msi_tag_extractor_test.cc
./omaha/hammer.bat MODE=dbg-win --build_server

# Verify tests were built
./omaha/scons-out/dbg-win/staging/omaha_unittest.exe --gtest_filter=MsiTagExtractorTest* --gtest_list_tests

# Run MsiTagExtractor tests from staging
# On master: pass
# With this change: pass
./omaha/scons-out/dbg-win/staging/omaha_unittest.exe --gtest_filter=MsiTagExtractorTest*

# Copy build output to a different folder
mkdir ./tmp
cp -r ./omaha/scons-out/dbg-win/staging/* ./tmp

# Verify files were copied correctly
ls ./tmp/omaha_unittest.exe
ls ./tmp/unittest_support/tagged_msi

# Run MsiTagExtractor tests from tmp
# On master: **fail**
# With this change: pass
./tmp/omaha_unittest.exe --gtest_filter=MsiTagExtractorTest*
```

Example test failure output on master
```
[----------] 12 tests from MsiTagExtractorTest
[ RUN      ] MsiTagExtractorTest.ValidTag
enterprise\installer\custom_actions\msi_tag_extractor_test.cc(37): error: Value of: File::Exists(unittest_file_path_)
  Actual: false
Expected: true
enterprise\installer\custom_actions\msi_tag_extractor_test.cc(43): error: Value of: File::Exists(tagged_msi_path)
  Actual: false
Expected: true
enterprise\installer\custom_actions\msi_tag_extractor_test.cc(55): error: Value of: tag_extractor.ReadTagFromFile(tagged_msi.c_str())
  Actual: false
Expected: true
enterprise\installer\custom_actions\msi_tag_extractor_test.cc(58): error: Value of: tag_extractor.GetValue("brand", &brand_code)
  Actual: false
Expected: true
enterprise\installer\custom_actions\msi_tag_extractor_test.cc(59): error: Expected equality of these values:
  brand_code.compare("QAQA")
    Which is: -1
  0
[  FAILED  ] MsiTagExtractorTest.ValidTag (1 ms)
```