### PR TITLE
Verify registry key/value exists: fixes updater crash in debug mode

### DIFF
--- a/omaha/common/experiment_labels.cc
+++ b/omaha/common/experiment_labels.cc
@@ -377,8 +377,10 @@ HRESULT ExperimentLabels::WriteRegistry(bool is_machine,
   if (is_machine) {
     const CString med_state_key(
         app_registry_utils::GetAppClientStateMediumKey(is_machine, app_id));
-    VERIFY_SUCCEEDED(RegKey::DeleteValue(med_state_key,
-                                          kRegValueExperimentLabels));
+    if (RegKey::HasValue(med_state_key, kRegValueExperimentLabels)) {
+      VERIFY_SUCCEEDED(
+          RegKey::DeleteValue(med_state_key, kRegValueExperimentLabels));
+    }
   }
 
   return hr;


### PR DESCRIPTION
If running as machine and the response from server contains experiment labels, the client tries to delete experiment_labels value from "HKLM\\Software\\Google\\Update\\ClientStateMedium\\{XXXX-XXXX-XXXX-XXX-XXXXX}" registry key without checking whether the key exists. Under some circumstances, it doesn't exist thus failing the assert and resulting in a crash. (e.g. a new install from GoogleUpdateSetup.exe)