### PR TITLE
Lighten deps of ComRegisterShell

### DIFF
--- a/omaha/goopdate/build.scons
+++ b/omaha/goopdate/build.scons
@@ -94,13 +94,11 @@ def BuildCOMRegisterShell64():
           '$LIB_DIR/common_64.lib',
           '$LIB_DIR/logging_64.lib',
           '$LIB_DIR/goopdate_lib_64.lib',
-          '$LIB_DIR/security_64.lib',
           com_register_shell_env['atls_libs'][
               com_register_shell_env.Bit('debug')
           ],
           com_register_shell_env['crt_libs'][
               com_register_shell_env.Bit('debug')],
-          'crypt32.lib',
           'delayimp.lib',
           'netapi32.lib',
           'psapi.lib',

--- a/omaha/goopdate/com_register_shell.cc
+++ b/omaha/goopdate/com_register_shell.cc
@@ -17,14 +17,12 @@
 #include <tchar.h>
 #include <strsafe.h>
 #include <windows.h>
-#include "base/basictypes.h"
 #include "omaha/base/app_util.h"
 #include "omaha/base/command_line_parser.h"
 #include "omaha/base/constants.h"
 #include "omaha/base/debug.h"
 #include "omaha/base/error.h"
 #include "omaha/base/logging.h"
-#include "omaha/base/path.h"
 #include "omaha/base/scope_guard.h"
 #include "omaha/base/utils.h"
 #include "omaha/common/const_cmd_line.h"


### PR DESCRIPTION
Found while doing a pass of ComRegisterShell:
1. security_64.lib and crypt.lib are unused, and can be removed
2. basictypes.h and path.h are unused, and can be removed

This passes our build and all tests downstream on Edge.