### PR TITLE
Load usage stats consent from the registry into the App object

### DIFF
--- a/omaha/goopdate/app.h
+++ b/omaha/goopdate/app.h
@@ -468,7 +468,7 @@ class App : public ModelObject {
   int day_of_install_;
   int day_of_last_response_;
 
-  // This value is stored in ClientState but not currently populated from there.
+  // This value is stored in ClientState.
   Tristate usage_stats_enable_;
 
   // This value is stored by the clients in one of several registry locations.

--- a/omaha/goopdate/app_manager.cc
+++ b/omaha/goopdate/app_manager.cc
@@ -552,6 +552,7 @@ HRESULT AppManager::ReadAppDefinedAttributeSubkeys(
 //    ping_freshness
 //  ClientState and ClientStateMedium key
 //    eulaaccepted
+//    usagestats
 //  ClientState key in HKCU/HKLM/Low integrity
 //    did run
 //
@@ -731,6 +732,8 @@ HRESULT AppManager::ReadAppPersistentData(App* app) {
                                           &ping_freshness))) {
     app->ping_freshness_ = ping_freshness;
   }
+
+  app->usage_stats_enable_ = GetAppUsageStatsEnabled(app_guid);
 
   return S_OK;
 }
@@ -1429,6 +1432,19 @@ uint32 AppManager::GetDayOfInstall(const GUID& app_guid) const {
   // No DayOfInstall is present. This app is probably installed before
   // DayOfInstall was implemented. Do not send DayOfInstall in this case.
   return kUnknownDayOfInstall;
+}
+
+Tristate AppManager::GetAppUsageStatsEnabled(const GUID& app_guid) const {
+  if (!IsAppRegistered(app_guid) && !IsAppUninstalled(app_guid)) {
+    return TRISTATE_NONE;
+  }
+
+  if (app_registry_utils::AreAppUsageStatsEnabled(is_machine_,
+                                                  GuidToString(app_guid))) {
+    return TRISTATE_TRUE;
+  }
+
+  return TRISTATE_FALSE;
 }
 
 // Clear the Installation ID if at least one of the conditions is true:

--- a/omaha/goopdate/app_manager.h
+++ b/omaha/goopdate/app_manager.h
@@ -208,6 +208,12 @@ class AppManager {
   // Omaha will not send day_of_install if it is 0.
   uint32 GetDayOfInstall(const GUID& app_guid) const;
 
+  // Returns a Tristate of whether usage stats are enabled.
+  //   Returns TRISTATE_NONE for unregistered apps.
+  //   Returns TRISTATE_TRUE if usage stats consent is true.
+  //   Returns TRISTATE_FALSE if usage stats consent is false or is unset.
+  Tristate GetAppUsageStatsEnabled(const GUID& app_guid) const;
+
   bool IsAppRegistered(const CString& app_id) const;
   bool IsAppUninstalled(const CString& app_id) const;
   bool IsAppOemInstalledAndEulaAccepted(const CString& app_id) const;

--- a/omaha/goopdate/app_manager_unittest.cc
+++ b/omaha/goopdate/app_manager_unittest.cc
@@ -258,6 +258,9 @@ class AppManagerTestBase : public AppTestBaseWithRegistryOverride {
           kRegValueDayOfLastRollCall,
           static_cast<DWORD>(num_days_since)));
     }
+
+    ASSERT_SUCCEEDED(app_registry_utils::SetUsageStatsEnable(
+        is_machine, app.app_guid_string(), app.usage_stats_enable()));
   }
 
   // App will be cleaned up when bundle is destroyed.
@@ -303,6 +306,7 @@ class AppManagerTestBase : public AppTestBaseWithRegistryOverride {
     expected_app->did_run_ = ACTIVE_RUN;
     expected_app->set_days_since_last_active_ping(3);
     expected_app->set_days_since_last_roll_call(1);
+    expected_app->usage_stats_enable_ = TRISTATE_TRUE;
   }
 
   static void PopulateExpectedApp2(App* expected_app) {
@@ -318,6 +322,7 @@ class AppManagerTestBase : public AppTestBaseWithRegistryOverride {
     expected_app->did_run_ = ACTIVE_NOTRUN;
     expected_app->set_days_since_last_active_ping(100);
     expected_app->set_days_since_last_roll_call(1);
+    expected_app->usage_stats_enable_ = TRISTATE_FALSE;
   }
 
   static void PopulateExpectedUninstalledApp(const CString& uninstalled_version,
@@ -2131,6 +2136,11 @@ TEST_F(AppManagerReadAppPersistentDataUserTest,
   EXPECT_SUCCEEDED(app_manager_->ReadAppPersistentData(app_));
 
   SetDisplayName(kDefaultAppName, expected_app);
+
+  // This is an unregistered app, and |AppManager::GetAppUsageStatsEnabled|
+  // returns TRISTATE_NONE for unregistered apps.
+  EXPECT_SUCCEEDED(expected_app->put_usageStatsEnable(TRISTATE_NONE));
+
   EXPECT_SUCCEEDED(expected_app->put_isEulaAccepted(VARIANT_TRUE));
   ValidateExpectedValues(*expected_app, *app_);
 }
@@ -2151,6 +2161,11 @@ TEST_F(AppManagerReadAppPersistentDataMachineTest,
   EXPECT_SUCCEEDED(app_manager_->ReadAppPersistentData(app_));
 
   SetDisplayName(kDefaultAppName, expected_app);
+
+  // This is an unregistered app, and |AppManager::GetAppUsageStatsEnabled|
+  // returns TRISTATE_NONE for unregistered apps.
+  EXPECT_SUCCEEDED(expected_app->put_usageStatsEnable(TRISTATE_NONE));
+
   EXPECT_SUCCEEDED(expected_app->put_isEulaAccepted(VARIANT_TRUE));
   ValidateExpectedValues(*expected_app, *app_);
 }


### PR DESCRIPTION
Update `AppManager::ReadPersistentData` to also load the persisted `usagestats` consent state from the registry into the `App` object. This allows the `App` object to know its usage stats consent state elsewhere in the update process, e.g. while building pings.

App manager unit tests are updated to cover the behavior. Build and tests all pass downstream on Edge.