### PR TITLE
Avoid BITS getting stuck in queued state during user logoff

### DIFF
--- a/omaha/base/error.h
+++ b/omaha/base/error.h
@@ -96,6 +96,11 @@ const ULONG kFacilityOmaha = 67;
 #define CI_E_BITS_DISABLED                        \
     MAKE_HRESULT(SEVERITY_ERROR, kFacilityOmaha, 0x0030)
 
+// CI_E_BITS_REQUEUED is returned by a BITS request if a job is moved back from
+// transmitting state to queued state due to a user session switch or logoff.
+#define CI_E_BITS_REQUEUED                        \
+    MAKE_HRESULT(SEVERITY_ERROR, kFacilityOmaha, 0x0031)
+
 // CI_E_HTTPS_CERT_FAILURE is returned when the https connection fails.
 // One cause of this is when the system clock is off by a significant
 // amount which makes the server certificate appear invalid.


### PR DESCRIPTION
BITS is a downloader designed with download queues in mind which can be manipulated by different users. Part of the design is to take into consideration that if a user logs-off then a job that was started by the user should be put back in queue until the user logs back in. This design does not work well for Omaha system-level installs which impersonate users to access proxy information but do not have the intention to suspend jobs during logoff.

Working around the behavior:
Changing how impersonation scoping works on those requests would be risky at this point. So, we're putting a surgical fix for this specific case. If a bits job ever reaches transferring state and "goes back" to queued, then we log a warning and let the download use a fallback instead of blocking on a sleep loop.

Examples of problematic scenario:
* A download starts over BITS while user A is logged in.
* User A logs off.
* User B logs in and user A does not log back in for weeks.
Result: the job is queued, an omaha process is blocked for days (eventually killed by a watchdog)

Examples of problematic scenario:
* An Omaha download starts while user A is logged in.
* User A logs off, leaves the device in the lock screen
* A critical update is needed.
Result: the device does not receive the new update as the previous is in the queue for days.
