### PR TITLE
ReadEntireFile: allow for either LF or CRLF line endings

### DIFF
--- a/omaha/base/utils_unittest.cc
+++ b/omaha/base/utils_unittest.cc
@@ -145,7 +145,7 @@ TEST(UtilsTest, ReadEntireFile) {
   ASSERT_FAILED(ReadEntireFile(L"C:\\F00Bar\\ImaginaryFile", 0, &buffer));
 
   ASSERT_SUCCEEDED(ReadEntireFile(file_name, 0, &buffer));
-  ASSERT_EQ(9405, buffer.size());
+  ASSERT_TRUE(9405 == buffer.size() /*LF*/ || 9514 == buffer.size() /*CRLF*/);
   buffer.resize(0);
   ASSERT_FAILED(ReadEntireFile(L"C:\\WINDOWS\\Greenstone.bmp", 1000, &buffer));
 }


### PR DESCRIPTION
Fixes: #328