### PR TITLE
Fix LogWriter Unregister

### DIFF
--- a/omaha/base/logging.cc
+++ b/omaha/base/logging.cc
@@ -965,7 +965,7 @@ bool LogWriter::Register() {
 bool LogWriter::Unregister() {
   Logging* logger = GetLogging();
   if (logger) {
-    return logger->RegisterWriter(this);
+    return logger->UnregisterWriter(this);
   } else {
     return false;
   }


### PR DESCRIPTION
`LogWriter::Unregister` calls `Logging::RegisterWriter` when it should call `Logging::UnregisterWriter`