### PR TITLE
Fix a Y2038 bug by replacing `Int32x32To64` with regular multiplication

### DIFF
--- a/omaha/base/time.cc
+++ b/omaha/base/time.cc
@@ -300,7 +300,7 @@ time_t FileTimeToTimeT(const FILETIME& file_time) {
 void TimeTToFileTime(const time_t& time, FILETIME* file_time) {
   ASSERT1(file_time);
 
-  LONGLONG ll = Int32x32To64(time, kSecsTo100ns) + kTimeTConvValue;
+  LONGLONG ll = (static_cast<LONGLONG>(time) * kSecsTo100ns) + kTimeTConvValue;
   file_time->dwLowDateTime = static_cast<DWORD>(ll);
   file_time->dwHighDateTime = static_cast<DWORD>(ll >> 32);
 }


### PR DESCRIPTION
`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>